### PR TITLE
[#171549167] Fix typo for ApiUserAdmin value in UserGroup enum

### DIFF
--- a/src/utils/middlewares/azure_api_auth.ts
+++ b/src/utils/middlewares/azure_api_auth.ts
@@ -25,7 +25,7 @@ import { IRequestMiddleware } from "../request_middleware";
  */
 export enum UserGroup {
   // API management users: get, list, create user's subscriptions and groups
-  ApiUserAdmin = "AipUserAdmin",
+  ApiUserAdmin = "ApiUserAdmin",
 
   // profiles: read limited profile (without addresses)
   ApiLimitedProfileRead = "ApiLimitedProfileRead",


### PR DESCRIPTION
This PR aims to correct a typo for the value of `ApiUserAdmin` in `UserGroup` enum.