### PR TITLE
[#173351990] fromQueryEither

### DIFF
--- a/src/utils/__tests__/documentdb.test.ts
+++ b/src/utils/__tests__/documentdb.test.ts
@@ -724,7 +724,7 @@ describe("fromQueryEither", () => {
 
     const errorMessage = "generic error";
     const queryFn: () => Promise<
-      Either<DocumentDb.QueryError | Error, IExpectedResultType>
+      Either<DocumentDb.QueryError, IExpectedResultType>
     > = async () => {
       throw new Error(errorMessage);
     };

--- a/src/utils/documentdb.ts
+++ b/src/utils/documentdb.ts
@@ -806,7 +806,7 @@ export type QueryError =
  * @returns either the query result or a query failure
  */
 export const fromQueryEither = <R>(
-  lazyPromise: () => Promise<Either<DocumentDb.QueryError | Error, R>>
+  lazyPromise: () => Promise<Either<DocumentDb.QueryError, R>>
 ): TaskEither<QueryError, R> =>
   tryCatch(lazyPromise, toError).foldTaskEither<QueryError, R>(
     err => fromEither(left({ code: "error", body: err.message })),


### PR DESCRIPTION
## Motivation
Our db interfaces return results in the unpleasant form `Promise<Either<QueryError, T>>` while a form `TaskEither<QueryError, T>` would be preferrable. `fromQueryEither` is a helper method that does such type conversion.
This helper [has been used extensively in our codebase](https://github.com/search?q=fromQueryEither+user%3Apagopa&type=Code&ref=advsearch&l=&l=) and it needs to be defined as a common util to avoid duplication.

## Implementation
- Cosmos' query errors are returned as left 
- Runtime errors (that is: when the promise rejects for unexpected problems) are mapped in the form `{code: "error", body: error.message}` to mock the interface of Cosmos' QueryError type
- a convenient `DocumentDbUtils.QueryError` type is defined to map such union 

## Usage
see [test snippets](https://github.com/pagopa/io-functions-commons/blob/1beb3a112c55111f7633505aeec41326df863fa2/src/utils/__tests__/documentdb.test.ts#L676).
