### PR TITLE
[#171554236] Document IDs as NonEmptyString

### DIFF
--- a/src/models/__tests__/user_data_processing.test.ts
+++ b/src/models/__tests__/user_data_processing.test.ts
@@ -7,6 +7,7 @@ import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";
 import { FiscalCode } from "../../../generated/definitions/FiscalCode";
 
 import { Container, FeedResponse, ResourceResponse } from "@azure/cosmos";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { UserDataProcessingChoiceEnum } from "../../../generated/definitions/UserDataProcessingChoice";
 import { UserDataProcessingStatusEnum } from "../../../generated/definitions/UserDataProcessingStatus";
 import {
@@ -30,7 +31,7 @@ const aRetrievedUserDataProcessing: RetrievedUserDataProcessing = {
   choice: aUserDataProcessingChoice,
   createdAt: aDate,
   fiscalCode: aFiscalCode,
-  id: aModelId,
+  id: (aModelId as unknown) as NonEmptyString,
   kind: "IRetrievedUserDataProcessing",
   status: aUserDataProcessingStatus,
   userDataProcessingId: aModelId,

--- a/src/utils/__tests__/cosmosdb_model.test.ts
+++ b/src/utils/__tests__/cosmosdb_model.test.ts
@@ -4,6 +4,7 @@ import { isLeft, isRight } from "fp-ts/lib/Either";
 
 import { Container, ErrorResponse, ResourceResponse } from "@azure/cosmos";
 
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { BaseModel, CosmosdbModel, ResourceT } from "../cosmosdb_model";
 
 beforeEach(() => {
@@ -42,7 +43,7 @@ const containerMock = {
 const container = (containerMock as unknown) as Container;
 
 const aDocument = {
-  id: "test-id-1",
+  id: "test-id-1" as NonEmptyString,
   test: "test"
 };
 

--- a/src/utils/cosmosdb_model.ts
+++ b/src/utils/cosmosdb_model.ts
@@ -16,21 +16,22 @@ import {
   ItemDefinition,
   ItemResponse,
   RequestOptions,
-  Resource,
   SqlQuerySpec
 } from "@azure/cosmos";
 
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { mapAsyncIterable } from "./async";
 import { isDefined } from "./types";
 
 export const BaseModel = t.interface({
-  id: t.string // FIXME: should this be a NonEmptyString?
+  id: NonEmptyString
 });
 
 export type BaseModel = t.TypeOf<typeof BaseModel>;
 
 // An io-ts definition of Cosmos Resource runtime type
-// tslint:disable-next-line: no-useless-cast
+// IDs are enforced to be non-empty string, as we're sure they are alway valued when coming from db.
+export type ResourceT = t.TypeOf<typeof ResourceT>;
 export const ResourceT = t.intersection([
   t.interface({
     _etag: t.string,
@@ -39,7 +40,7 @@ export const ResourceT = t.intersection([
     _ts: t.number
   }),
   BaseModel
-]) as t.Type<Resource>;
+]);
 
 // An empty response from a Cosmos operation
 export const CosmosEmptyResponse = {

--- a/src/utils/cosmosdb_model.ts
+++ b/src/utils/cosmosdb_model.ts
@@ -31,7 +31,7 @@ export const BaseModel = t.interface({
 export type BaseModel = t.TypeOf<typeof BaseModel>;
 
 // An io-ts definition of Cosmos Resource runtime type
-// IDs are enforced to be non-empty string, as we're sure they are alway valued when coming from db.
+// IDs are enforced to be non-empty string, as we're sure they are always valued when coming from db.
 export type ResourceT = t.TypeOf<typeof ResourceT>;
 // tslint:disable-next-line: no-useless-cast
 export const ResourceT = t.intersection([

--- a/src/utils/cosmosdb_model.ts
+++ b/src/utils/cosmosdb_model.ts
@@ -16,6 +16,7 @@ import {
   ItemDefinition,
   ItemResponse,
   RequestOptions,
+  Resource,
   SqlQuerySpec
 } from "@azure/cosmos";
 
@@ -31,6 +32,7 @@ export type BaseModel = t.TypeOf<typeof BaseModel>;
 
 // An io-ts definition of Cosmos Resource runtime type
 // IDs are enforced to be non-empty string, as we're sure they are alway valued when coming from db.
+// tslint:disable-next-line: no-unnecessary-cast
 export type ResourceT = t.TypeOf<typeof ResourceT>;
 export const ResourceT = t.intersection([
   t.interface({
@@ -40,7 +42,7 @@ export const ResourceT = t.intersection([
     _ts: t.number
   }),
   BaseModel
-]);
+]) as t.Type<Resource & { id: NonEmptyString }>; // this cast is needed to keep ResourceT in sync with Resource (try to remove a field from the decoder definition and you'll face an error)
 
 // An empty response from a Cosmos operation
 export const CosmosEmptyResponse = {

--- a/src/utils/cosmosdb_model.ts
+++ b/src/utils/cosmosdb_model.ts
@@ -32,8 +32,8 @@ export type BaseModel = t.TypeOf<typeof BaseModel>;
 
 // An io-ts definition of Cosmos Resource runtime type
 // IDs are enforced to be non-empty string, as we're sure they are alway valued when coming from db.
-// tslint:disable-next-line: no-unnecessary-cast
 export type ResourceT = t.TypeOf<typeof ResourceT>;
+// tslint:disable-next-line: no-useless-cast
 export const ResourceT = t.intersection([
   t.interface({
     _etag: t.string,


### PR DESCRIPTION
Enforce document IDs as NonEmptyString. This is to avoid manual casting when using objects coming from db (example: fetch a document, edit a field, save the document).

The assumption is safe as `id` field is never empty on Cosmos document. 

What we are losing with these changes is the direct relation between the decoder `ResourceT` and the type `@azure/cosmos/Resource`. This has been mitigated by the introduction of type `ResourceT` and [this cast](https://github.com/pagopa/io-functions-commons/blob/11ae8056e02750220c50eec905f04de1f42a0ae9/src/utils/cosmosdb_model.ts#L45).

`ResourceT` is actually an extension of `@azure/cosmos/Resource`, and hence we should prefer the former to the latter. I see we don't use such kind explicitly in our codebase, though.

