### PR TITLE
cosmosDB model bugfix

### DIFF
--- a/src/models/__e2e__/integration_tests.ts
+++ b/src/models/__e2e__/integration_tests.ts
@@ -2,6 +2,7 @@
 import * as messageIntegration from "./message_integration";
 import * as profileIntegration from "./profile_integration";
 import * as serviceIntegration from "./service_integration";
+import * as udpIntegration from "./user_data_processing_integration";
 
 serviceIntegration
   .test()
@@ -12,6 +13,10 @@ profileIntegration
   .then()
   .catch(console.error);
 messageIntegration
+  .test()
+  .then()
+  .catch(console.error);
+udpIntegration
   .test()
   .then()
   .catch(console.error);

--- a/src/models/__e2e__/profile_integration.ts
+++ b/src/models/__e2e__/profile_integration.ts
@@ -80,7 +80,7 @@ const upsertTest = createDatabase(cosmosDatabaseName)
       kind: "INewProfile",
       ...aProfile,
       email: "emailUpdated@example.com" as EmailString,
-      version: (undefined as unknown) as NonNegativeInteger
+      version: undefined
     })
   );
 

--- a/src/models/__e2e__/service_integration.ts
+++ b/src/models/__e2e__/service_integration.ts
@@ -89,7 +89,8 @@ const upsertTest = createDatabase(cosmosDatabaseName)
     new ServiceModel(container).upsert({
       kind: "INewService",
       ...aService,
-      serviceName: "anUpdatedServiceName" as NonEmptyString
+      serviceName: "anUpdatedServiceName" as NonEmptyString,
+      version: undefined
     })
   );
 

--- a/src/models/__e2e__/user_data_processing_integration.ts
+++ b/src/models/__e2e__/user_data_processing_integration.ts
@@ -1,0 +1,128 @@
+// tslint:disable: no-console no-identical-functions
+import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
+
+import { isLeft, right } from "fp-ts/lib/Either";
+import { fromEither, fromLeft, taskEither } from "fp-ts/lib/TaskEither";
+import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";
+import { UserDataProcessingChoiceEnum } from "../../../generated/definitions/UserDataProcessingChoice";
+import { UserDataProcessingStatusEnum } from "../../../generated/definitions/UserDataProcessingStatus";
+import {
+  makeUserDataProcessingId,
+  RetrievedUserDataProcessing,
+  USER_DATA_PROCESSING_COLLECTION_NAME,
+  USER_DATA_PROCESSING_MODEL_ID_FIELD,
+  USER_DATA_PROCESSING_MODEL_PK_FIELD,
+  UserDataProcessing,
+  UserDataProcessingModel
+} from "../user_data_processing";
+import {
+  cosmosDatabaseName,
+  createContainer,
+  createDatabase
+} from "./integration_init";
+
+const aUserDataProcessingChoice = UserDataProcessingChoiceEnum.DOWNLOAD;
+const aUserDataProcessingStatus = UserDataProcessingStatusEnum.PENDING;
+const aFiscalCode = "RLDBSV36A78Y792X" as FiscalCode;
+
+const aUserDataProcessing: UserDataProcessing = UserDataProcessing.decode({
+  choice: aUserDataProcessingChoice,
+  createdAt: new Date(),
+  fiscalCode: aFiscalCode,
+  status: aUserDataProcessingStatus,
+  userDataProcessingId: makeUserDataProcessingId(
+    aUserDataProcessingChoice,
+    aFiscalCode
+  )
+}).getOrElseL(() => {
+  throw new Error("Cannot decode userdataprocessing payload.");
+});
+
+const aRetrievedUserDataProcessing: RetrievedUserDataProcessing = {
+  _etag: "_etag",
+  _rid: "_rid",
+  _self: "_self",
+  _ts: 1,
+  choice: aUserDataProcessingChoice,
+  createdAt: new Date(),
+  fiscalCode: aFiscalCode,
+  id: `${aUserDataProcessing[USER_DATA_PROCESSING_MODEL_ID_FIELD]}-0000000000000000` as NonEmptyString,
+  kind: "IRetrievedUserDataProcessing",
+  status: aUserDataProcessingStatus,
+  userDataProcessingId:
+    aUserDataProcessing[USER_DATA_PROCESSING_MODEL_ID_FIELD],
+  version: 0 as NonNegativeInteger
+};
+
+const createTest = createDatabase(cosmosDatabaseName)
+  .chain(db =>
+    createContainer(
+      db,
+      USER_DATA_PROCESSING_COLLECTION_NAME,
+      USER_DATA_PROCESSING_MODEL_PK_FIELD
+    )
+  )
+  .chain(container =>
+    new UserDataProcessingModel(container).create({
+      kind: "INewUserDataProcessing",
+      ...aUserDataProcessing
+    })
+  );
+
+const retrieveTest = (modelId: string) =>
+  createDatabase(cosmosDatabaseName)
+    .chain(db =>
+      createContainer(
+        db,
+        USER_DATA_PROCESSING_COLLECTION_NAME,
+        USER_DATA_PROCESSING_MODEL_PK_FIELD
+      )
+    )
+    .chain(container =>
+      new UserDataProcessingModel(container).findLastVersionByModelId(modelId)
+    );
+
+const upsertTest = createDatabase(cosmosDatabaseName)
+  .chain(db =>
+    createContainer(
+      db,
+      USER_DATA_PROCESSING_COLLECTION_NAME,
+      USER_DATA_PROCESSING_MODEL_PK_FIELD
+    )
+  )
+  .chain(container =>
+    new UserDataProcessingModel(container).createOrUpdateByNewOne({
+      ...aRetrievedUserDataProcessing,
+      status: UserDataProcessingStatusEnum.WIP,
+      updatedAt: new Date()
+    })
+  );
+
+export const test = () =>
+  createTest
+    .foldTaskEither(
+      err => {
+        if (err.kind === "COSMOS_ERROR_RESPONSE" && err.error.code === 409) {
+          console.log(
+            "UserDataProcessing-CreateTest| A document with the same id already exists"
+          );
+          return taskEither.of(aRetrievedUserDataProcessing);
+        } else {
+          return fromLeft(err);
+        }
+      },
+      _ => fromEither(right(_))
+    )
+    .chain(_ => upsertTest)
+    .chain(_ => retrieveTest(_[USER_DATA_PROCESSING_MODEL_ID_FIELD]))
+    .run()
+    .then(_ => {
+      if (isLeft(_)) {
+        console.log(`UserDataProcessing-Test| Error = ${_.value}`);
+        console.log(_.value);
+      } else {
+        console.log("UserDataProcessing-Test| success!");
+        console.log(_.value);
+      }
+    })
+    .catch(console.error);

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -26,7 +26,12 @@ import { MessageContent } from "../../generated/definitions/MessageContent";
 
 import { FiscalCode } from "../../generated/definitions/FiscalCode";
 
-import { Container, FeedOptions, SqlQuerySpec } from "@azure/cosmos";
+import {
+  Container,
+  FeedOptions,
+  FeedResponse,
+  SqlQuerySpec
+} from "@azure/cosmos";
 import {
   fromEither as fromEitherT,
   fromLeft,
@@ -252,12 +257,14 @@ export class MessageModel extends CosmosdbModel<
     CosmosErrors,
     Option<ReadonlyArray<RetrievedMessageWithoutContent>>
   > {
-    const fetchAll = this.container.items.query<RetrievedMessageWithoutContent>(
-      query,
-      options
-    ).fetchAll;
-    return tryCatchT<CosmosErrors, PromiseType<ReturnType<typeof fetchAll>>>(
-      () => fetchAll(),
+    return tryCatchT<
+      CosmosErrors,
+      FeedResponse<readonly RetrievedMessageWithoutContent[]>
+    >(
+      () =>
+        this.container.items
+          .query<readonly RetrievedMessageWithoutContent[]>(query, options)
+          .fetchAll(),
       toCosmosErrorResponse
     )
       .map(_ => fromNullable(_.resources))

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -12,7 +12,6 @@ import { fromNullable, none, Option, some } from "fp-ts/lib/Option";
 import * as t from "io-ts";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
-import { PromiseType } from "italia-ts-commons/lib/types";
 import {
   BaseModel,
   CosmosdbModel,

--- a/src/models/user_data_processing.ts
+++ b/src/models/user_data_processing.ts
@@ -123,8 +123,9 @@ export class UserDataProcessingModel extends CosmosdbModelVersioned<
     const toUpdate: NewUserDataProcessing = {
       ...userDataProcessing,
       kind: "INewUserDataProcessing",
-      [USER_DATA_PROCESSING_MODEL_ID_FIELD]: newId
+      [USER_DATA_PROCESSING_MODEL_ID_FIELD]: newId,
+      version: undefined
     };
-    return this.upsert(toUpdate);
+    return this.upsert(toUpdate, undefined, toUpdate.fiscalCode);
   }
 }

--- a/src/utils/cosmosdb_model_versioned.ts
+++ b/src/utils/cosmosdb_model_versioned.ts
@@ -126,11 +126,7 @@ export abstract class CosmosdbModelVersioned<
     // if we get an explicit version number from the new document we use that,
     // or else we get the last version by querying the database
     const currentVersion: NonNegativeInteger | undefined = o.version;
-    // tslint:disable-next-line: no-console
-    console.log(`currentVersion => ${currentVersion}`);
     const modelId = this.getModelId(o);
-    // tslint:disable-next-line: no-console
-    console.log(`modelId => ${modelId}`);
     return (currentVersion === undefined
       ? this.getNextVersion(modelId, partitionKey)
       : fromEither<CosmosErrors, NonNegativeInteger>(right(currentVersion))

--- a/src/utils/cosmosdb_model_versioned.ts
+++ b/src/utils/cosmosdb_model_versioned.ts
@@ -66,7 +66,7 @@ export function generateVersionedModelId(
   return `${modelId}-${paddedVersion}`;
 }
 
-const incVersion = (version: NonNegativeInteger) =>
+export const incVersion = (version: NonNegativeInteger) =>
   (Number(version) + 1) as NonNegativeInteger;
 
 /**
@@ -118,20 +118,31 @@ export abstract class CosmosdbModelVersioned<
   /**
    * Creates a new version from a full item definition
    */
-  public upsert = (o: TN): TaskEither<CosmosErrors, TR> => {
+  public upsert = (
+    o: TN,
+    requestOptions?: RequestOptions,
+    partitionKey?: string
+  ): TaskEither<CosmosErrors, TR> => {
     // if we get an explicit version number from the new document we use that,
     // or else we get the last version by querying the database
     const currentVersion: NonNegativeInteger | undefined = o.version;
+    // tslint:disable-next-line: no-console
+    console.log(`currentVersion => ${currentVersion}`);
     const modelId = this.getModelId(o);
+    // tslint:disable-next-line: no-console
+    console.log(`modelId => ${modelId}`);
     return (currentVersion === undefined
-      ? this.getNextVersion(modelId)
+      ? this.getNextVersion(modelId, partitionKey)
       : fromEither<CosmosErrors, NonNegativeInteger>(right(currentVersion))
     ).chain(nextVersion =>
-      super.create({
-        ...o,
-        id: generateVersionedModelId(modelId, nextVersion),
-        version: nextVersion
-      } as TN & RetrievedVersionedModel)
+      super.create(
+        {
+          ...o,
+          id: generateVersionedModelId(modelId, nextVersion),
+          version: nextVersion
+        } as TN & RetrievedVersionedModel,
+        requestOptions
+      )
     );
   };
 
@@ -174,8 +185,8 @@ export abstract class CosmosdbModelVersioned<
    * The next version will be the last one from the database incremented by 1 or
    * 0 if no previous version exists in the database.
    */
-  private getNextVersion = (modelId: ModelId) =>
-    this.findLastVersionByModelId(modelId).map(maybeLastVersion =>
+  private getNextVersion = (modelId: ModelId, partitionKey?: string) =>
+    this.findLastVersionByModelId(modelId, partitionKey).map(maybeLastVersion =>
       maybeLastVersion
         .map(_ => incVersion(_.version))
         .getOrElse(0 as NonNegativeInteger)


### PR DESCRIPTION
This PR contains:
- `getNextVersion` bug fix on versioned models that have partitionKey field different from ModelId field
- A binding error fix on `findAllByQuery` method
- Improvement of `createOrUpdateByNewOne` in order to manage correctly upsert operation
- Some integration tests