### PR TITLE
[#174189493] DocumentSearchKey type fix

### DIFF
--- a/src/utils/__tests__/cosmosdb_model.test.ts
+++ b/src/utils/__tests__/cosmosdb_model.test.ts
@@ -31,8 +31,7 @@ type RetrievedMyDocument = t.TypeOf<typeof RetrievedMyDocument>;
 class MyModel extends CosmosdbModel<
   MyDocument,
   NewMyDocument,
-  RetrievedMyDocument,
-  undefined
+  RetrievedMyDocument
 > {
   constructor(c: Container) {
     super(c, NewMyDocument, RetrievedMyDocument);

--- a/src/utils/cosmosdb_model_versioned.ts
+++ b/src/utils/cosmosdb_model_versioned.ts
@@ -74,7 +74,7 @@ export abstract class CosmosdbModelVersioned<
   TN extends Readonly<T & Partial<NewVersionedModel>>,
   TR extends Readonly<T & RetrievedVersionedModel>,
   ModelIdKey extends keyof T,
-  PartitionKey extends keyof T | undefined = undefined
+  PartitionKey extends keyof T = ModelIdKey
 > extends CosmosdbModel<T, TN & BaseModel, TR, PartitionKey> {
   constructor(
     container: Container,


### PR DESCRIPTION
Corrects a _what it seems to be_ Typescript unintended behaviour when comparing `undefined` type with other types.

### The bug
```ts
type Model = { foo: string }
type DSK = DocumentSearchKey<Model, "foo">
// expected: DSK = [string]
// actual: DSK = [string, never]
```
The point is that `PartitionKey` used to have a default on `undefined`, and then we compose `DSK`'s type based on the fact that `PartitionKey extends keyof T` or not. This somehow failed unexpectedly with inconsistent results. 

### The solution
Instead of using `undefined` as a "not present" placeholder, we now assume that "_no partition key --> partition key is the same of model id_" (which is how Cosmos works, though). Side effect is: 
```ts
type Model = { foo: string }
type DSK1 = DocumentSearchKey<Model, "foo">
type DSK2 = DocumentSearchKey<Model, "foo", "foo">
// DSK1 = DSK2 = [string]
```
