### PR TITLE
[#174189493] Fix NotificationModel partition key

### DIFF
--- a/src/models/notification.ts
+++ b/src/models/notification.ts
@@ -27,7 +27,7 @@ import { ObjectIdGenerator } from "../utils/strings";
 import { wrapWithKind } from "../utils/types";
 
 export const NOTIFICATION_COLLECTION_NAME = "notifications";
-export const NOTIFICATION_MODEL_PK_FIELD = "messageId";
+export const NOTIFICATION_MODEL_PK_FIELD = "messageId" as const;
 
 /**
  * All possible sources that can provide the address of the recipient.
@@ -149,7 +149,8 @@ export type RetrievedNotification = t.TypeOf<typeof RetrievedNotification>;
 export class NotificationModel extends CosmosdbModel<
   Notification,
   NewNotification,
-  RetrievedNotification
+  RetrievedNotification,
+  typeof NOTIFICATION_MODEL_PK_FIELD
 > {
   /**
    * Creates a new Notification model

--- a/src/models/user_data_processing.ts
+++ b/src/models/user_data_processing.ts
@@ -10,6 +10,7 @@ import {
 
 import { Container } from "@azure/cosmos";
 import { TaskEither } from "fp-ts/lib/TaskEither";
+import { readableReport } from "italia-ts-commons/lib/reporters";
 import { FiscalCode } from "../../generated/definitions/FiscalCode";
 import { Timestamp } from "../../generated/definitions/Timestamp";
 import { UserDataProcessingChoice } from "../../generated/definitions/UserDataProcessingChoice";
@@ -87,8 +88,10 @@ export function makeUserDataProcessingId(
   fiscalCode: FiscalCode
 ): UserDataProcessingId {
   return UserDataProcessingId.decode(`${fiscalCode}-${choice}`).getOrElseL(
-    () => {
-      throw new Error("Invalid User Data Processing id");
+    errors => {
+      throw new Error(
+        `Invalid User Data Processing id, reason: ${readableReport(errors)}`
+      );
     }
   );
 }


### PR DESCRIPTION
Add a partition key to `NotificationModel` (erroneously missing in previous releases)

Plus: better log on bad `UserDataProcessingId`