### PR TITLE
[#174189493] Review CosmosdbModelVersioned public interface

### DIFF
--- a/src/models/__e2e__/profile_integration.ts
+++ b/src/models/__e2e__/profile_integration.ts
@@ -57,8 +57,7 @@ const createTest = createDatabase(cosmosDatabaseName)
   .chain(container =>
     new ProfileModel(container).create({
       kind: "INewProfile",
-      ...aProfile,
-      version: 0 as NonNegativeInteger
+      ...aProfile
     })
   );
 
@@ -79,8 +78,7 @@ const upsertTest = createDatabase(cosmosDatabaseName)
     new ProfileModel(container).upsert({
       kind: "INewProfile",
       ...aProfile,
-      email: "emailUpdated@example.com" as EmailString,
-      version: undefined
+      email: "emailUpdated@example.com" as EmailString
     })
   );
 

--- a/src/models/__e2e__/service_integration.ts
+++ b/src/models/__e2e__/service_integration.ts
@@ -89,8 +89,7 @@ const upsertTest = createDatabase(cosmosDatabaseName)
     new ServiceModel(container).upsert({
       kind: "INewService",
       ...aService,
-      serviceName: "anUpdatedServiceName" as NonEmptyString,
-      version: undefined
+      serviceName: "anUpdatedServiceName" as NonEmptyString
     })
   );
 

--- a/src/models/message_status.ts
+++ b/src/models/message_status.ts
@@ -12,7 +12,6 @@ import { TaskEither } from "fp-ts/lib/TaskEither";
 import { CosmosErrors } from "../utils/cosmosdb_model";
 import {
   CosmosdbModelVersioned,
-  NewVersionedModel,
   RetrievedVersionedModel
 } from "../utils/cosmosdb_model_versioned";
 import { wrapWithKind } from "../utils/types";
@@ -32,7 +31,7 @@ export const MessageStatus = t.interface({
 export type MessageStatus = t.TypeOf<typeof MessageStatus>;
 
 export const NewMessageStatus = wrapWithKind(
-  t.intersection([MessageStatus, NewVersionedModel]),
+  MessageStatus,
   "INewMessageStatus" as const
 );
 

--- a/src/models/notification_status.ts
+++ b/src/models/notification_status.ts
@@ -4,7 +4,6 @@ import { tag } from "italia-ts-commons/lib/types";
 
 import {
   CosmosdbModelVersioned,
-  NewVersionedModel,
   RetrievedVersionedModel
 } from "../utils/cosmosdb_model_versioned";
 
@@ -51,7 +50,7 @@ export const NotificationStatus = t.interface({
 export type NotificationStatus = t.TypeOf<typeof NotificationStatus>;
 
 export const NewNotificationStatus = wrapWithKind(
-  t.intersection([NotificationStatus, NewVersionedModel]),
+  NotificationStatus,
   "INewNotificationStatus" as const
 );
 

--- a/src/models/profile.ts
+++ b/src/models/profile.ts
@@ -4,7 +4,6 @@ import { withDefault } from "italia-ts-commons/lib/types";
 
 import {
   CosmosdbModelVersioned,
-  NewVersionedModel,
   RetrievedVersionedModel
 } from "../utils/cosmosdb_model_versioned";
 
@@ -73,10 +72,7 @@ export const Profile = t.intersection([
 
 export type Profile = t.TypeOf<typeof Profile>;
 
-export const NewProfile = wrapWithKind(
-  t.intersection([Profile, NewVersionedModel]),
-  "INewProfile" as const
-);
+export const NewProfile = wrapWithKind(Profile, "INewProfile" as const);
 
 export type NewProfile = t.TypeOf<typeof NewProfile>;
 

--- a/src/models/service.ts
+++ b/src/models/service.ts
@@ -2,7 +2,6 @@ import * as t from "io-ts";
 
 import {
   CosmosdbModelVersioned,
-  NewVersionedModel,
   RetrievedVersionedModel
 } from "../utils/cosmosdb_model_versioned";
 
@@ -97,16 +96,11 @@ const ServiceO = t.partial({
   serviceMetadata: ServiceMetadata
 });
 
+export type Service = t.TypeOf<typeof Service>;
 export const Service = t.intersection([ServiceR, ServiceO], "Service");
 
-export type Service = t.TypeOf<typeof Service>;
-
-export const NewService = wrapWithKind(
-  t.intersection([Service, NewVersionedModel]),
-  "INewService" as const
-);
-
 export type NewService = t.TypeOf<typeof NewService>;
+export const NewService = wrapWithKind(Service, "INewService" as const);
 
 export const RetrievedService = wrapWithKind(
   t.intersection([Service, RetrievedVersionedModel]),

--- a/src/models/user_data_processing.ts
+++ b/src/models/user_data_processing.ts
@@ -4,7 +4,6 @@ import { tag } from "italia-ts-commons/lib/types";
 
 import {
   CosmosdbModelVersioned,
-  NewVersionedModel,
   RetrievedVersionedModel
 } from "../utils/cosmosdb_model_versioned";
 
@@ -68,7 +67,7 @@ export const UserDataProcessing = t.intersection([
 export type UserDataProcessing = t.TypeOf<typeof UserDataProcessing>;
 
 export const NewUserDataProcessing = wrapWithKind(
-  t.intersection([UserDataProcessing, NewVersionedModel]),
+  UserDataProcessing,
   "INewUserDataProcessing" as const
 );
 

--- a/src/models/user_data_processing.ts
+++ b/src/models/user_data_processing.ts
@@ -138,8 +138,7 @@ export class UserDataProcessingModel extends CosmosdbModelVersioned<
     const toUpdate: NewUserDataProcessing = {
       ...userDataProcessing,
       kind: "INewUserDataProcessing",
-      [USER_DATA_PROCESSING_MODEL_ID_FIELD]: newId,
-      version: undefined
+      [USER_DATA_PROCESSING_MODEL_ID_FIELD]: newId
     };
     return this.upsert(toUpdate);
   }

--- a/src/utils/__tests__/cosmosdb_model_versioned.test.ts
+++ b/src/utils/__tests__/cosmosdb_model_versioned.test.ts
@@ -201,10 +201,10 @@ describe("upsert", () => {
 describe("update", () => {
   it("should create a new document with explicit version", async () => {
     const expectedNextVersion = 0;
-    const modelId = aNewMyDocument[aModelIdField];
+    const modelId = aMyDocument[aModelIdField];
     const model = new MyModel(container);
 
-    const result = await model.create(aNewMyDocument).run();
+    const result = await model.create(aMyDocument).run();
 
     expect(containerMock.items.create).toHaveBeenCalledWith(
       {

--- a/src/utils/__tests__/cosmosdb_model_versioned.test.ts
+++ b/src/utils/__tests__/cosmosdb_model_versioned.test.ts
@@ -17,7 +17,6 @@ import { BaseModel } from "../cosmosdb_model";
 import {
   CosmosdbModelVersioned,
   generateVersionedModelId,
-  NewVersionedModel,
   RetrievedVersionedModel
 } from "../cosmosdb_model_versioned";
 
@@ -44,9 +43,6 @@ const MyDocument = t.interface({
 });
 type MyDocument = t.TypeOf<typeof MyDocument>;
 
-const NewMyDocument = t.intersection([MyDocument, NewVersionedModel]);
-type NewMyDocument = t.TypeOf<typeof NewMyDocument>;
-
 const RetrievedMyDocument = t.intersection([
   MyDocument,
   RetrievedVersionedModel,
@@ -56,19 +52,19 @@ type RetrievedMyDocument = t.TypeOf<typeof RetrievedMyDocument>;
 
 class MyModel extends CosmosdbModelVersioned<
   MyDocument,
-  NewMyDocument,
+  MyDocument,
   RetrievedMyDocument,
   typeof aModelIdField
 > {
   constructor(c: Container) {
-    super(c, NewMyDocument, RetrievedMyDocument, aModelIdField);
+    super(c, MyDocument, RetrievedMyDocument, aModelIdField);
   }
 }
 
 // tslint:disable-next-line: max-classes-per-file
 class MyPartitionedModel extends CosmosdbModelVersioned<
   MyDocument,
-  NewMyDocument,
+  MyDocument,
   RetrievedMyDocument,
   typeof aModelIdField,
   typeof aModelPartitionField
@@ -76,7 +72,7 @@ class MyPartitionedModel extends CosmosdbModelVersioned<
   constructor(c: Container) {
     super(
       c,
-      NewMyDocument,
+      MyDocument,
       RetrievedMyDocument,
       aModelIdField,
       aModelPartitionField
@@ -90,10 +86,6 @@ const aMyDocument = {
   [aModelIdField]: aModelIdValue,
   [aModelPartitionField]: aModelPartitionValue,
   test: "aNewMyDocument"
-};
-
-const aNewMyDocument: NewMyDocument = {
-  ...aMyDocument
 };
 
 const someMetadata = {
@@ -129,9 +121,9 @@ errorResponse.code = 500;
 
 describe("upsert", () => {
   it.each`
-    document          | currentlyOnDb                 | expectedVersion
-    ${aNewMyDocument} | ${undefined}                  | ${0}
-    ${aNewMyDocument} | ${aRetrievedExistingDocument} | ${aRetrievedExistingDocument.version + 1}
+    document       | currentlyOnDb                 | expectedVersion
+    ${aMyDocument} | ${undefined}                  | ${0}
+    ${aMyDocument} | ${aRetrievedExistingDocument} | ${aRetrievedExistingDocument.version + 1}
   `(
     "should create a document with version $expectedVersion",
     async ({ document, currentlyOnDb, expectedVersion }) => {
@@ -170,7 +162,7 @@ describe("upsert", () => {
     });
     const model = new MyModel(container);
 
-    const result = await model.upsert(aNewMyDocument).run();
+    const result = await model.upsert(aMyDocument).run();
     expect(isLeft(result));
     if (isLeft(result)) {
       expect(result.value.kind).toBe("COSMOS_ERROR_RESPONSE");
@@ -187,7 +179,7 @@ describe("upsert", () => {
     containerMock.items.create.mockRejectedValueOnce(errorResponse);
     const model = new MyModel(container);
 
-    const result = await model.upsert(aNewMyDocument).run();
+    const result = await model.upsert(aMyDocument).run();
     expect(isLeft(result));
     if (isLeft(result)) {
       expect(result.value.kind).toBe("COSMOS_ERROR_RESPONSE");

--- a/src/utils/cosmosdb_model_versioned.ts
+++ b/src/utils/cosmosdb_model_versioned.ts
@@ -251,7 +251,26 @@ export abstract class CosmosdbModelVersioned<
    * Strips off meta fields which are nor part of the base model definition
    */
   private toBaseType(o: TR): T {
-    const { _etag, _rid, _self, _ts, id, version, ...n } = o;
-    return (n as unknown) as T;
+    // keys to remove
+    const removed: ReadonlyArray<keyof RetrievedVersionedModel> = [
+      "_etag",
+      "_rid",
+      "_self",
+      "_ts",
+      "id",
+      "version"
+    ]; // can we ensure we are getting ALL keys of RetrievedVersionedModel?
+
+    const skimmed: Omit<TR, keyof RetrievedVersionedModel> = removed.reduce(
+      (p, k) => {
+        const { [k]: x, ...n } = p;
+        return n;
+      },
+      // tslint:disable-next-line: no-any
+      o as any
+    );
+
+    // we know that T =  Omit<TR, keyof RetrievedVersionedModel>
+    return (skimmed as unknown) as T;
   }
 }


### PR DESCRIPTION
This introduces new methods and breaking changes to old ones for the purpose of handling different scenarios explicitly when saving versioned documents.

### Changes
* ~type `NewVersionedModel` doesn't include `version` field anymore.~
* type `NewVersionedModel` has been removed. `TN` is actually `T`, but it can be extended (to add tags for example).
* `create(o:TN)` creates a new document on db which version is always `0`.
* `upsert(o:TN)` creates a new document on db which version is calculated from the latest document present on db for the same modeld (`0` if no documents are found)
* `update(o: TR)` creates a new document on db which version is calculated as `o.version + 1`