### PR TITLE
[#174725389] move is_visible on ServicePayload

### DIFF
--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -550,6 +550,9 @@ ServicePayload:
     require_secure_channels:
       type: boolean
       default: false
+    is_visible:
+        type: boolean
+        default: false
     service_metadata:
       $ref: "#/ServiceMetadata"
   required:
@@ -577,9 +580,6 @@ Service:
           $ref: "#/FiscalCode"
       max_allowed_payment_amount:
         $ref: "#/MaxAllowedPaymentAmount"
-      is_visible:
-        type: boolean
-        default: false
     required:
       - service_id
       - authorized_recipients


### PR DESCRIPTION
This PR allows is_visible to be externally set, by moving it from `Service` to `ServicePayload`.