### PR TITLE
[#174770172] Service metadata attributes and mapping refactoring

### DIFF
--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -622,6 +622,15 @@ ServiceMetadata:
     pec:
       type: string
       minLength: 1
+    cta:
+      type: string
+      minLength: 1
+    token_name: 
+      type: string
+      minLength: 1
+    support_url:
+      type: string
+      minLength: 1
     scope:
       $ref: "#/ServiceScope"
   required:

--- a/src/models/service.ts
+++ b/src/models/service.ts
@@ -54,7 +54,13 @@ const ServiceMetadataO = t.partial({
 
   email: NonEmptyString,
 
-  pec: NonEmptyString
+  pec: NonEmptyString,
+
+  cta: NonEmptyString,
+
+  tokenName: NonEmptyString,
+
+  supportUrl: NonEmptyString
 });
 
 export const ServiceMetadata = t.intersection(

--- a/src/models/visible_service.ts
+++ b/src/models/visible_service.ts
@@ -14,6 +14,7 @@ import { ServicePublic } from "../../generated/definitions/ServicePublic";
 import { ServiceScopeEnum } from "../../generated/definitions/ServiceScope";
 import { ServiceTuple } from "../../generated/definitions/ServiceTuple";
 import { BaseModel } from "../utils/cosmosdb_model";
+import { toApiServiceMetadata } from "../utils/service_metadata";
 import { Service, ServiceMetadata } from "./service";
 
 // This is not a CosmosDB model, but entities are stored into blob storage
@@ -78,19 +79,7 @@ export function toServicePublic(visibleService: VisibleService): ServicePublic {
     organization_name: visibleService.organizationName,
     service_id: visibleService.serviceId,
     service_metadata: visibleService.serviceMetadata
-      ? {
-          address: visibleService.serviceMetadata.address,
-          app_android: visibleService.serviceMetadata.appAndroid,
-          app_ios: visibleService.serviceMetadata.appIos,
-          description: visibleService.serviceMetadata.description,
-          email: visibleService.serviceMetadata.email,
-          pec: visibleService.serviceMetadata.pec,
-          phone: visibleService.serviceMetadata.phone,
-          privacy_url: visibleService.serviceMetadata.privacyUrl,
-          scope: visibleService.serviceMetadata.scope,
-          tos_url: visibleService.serviceMetadata.tosUrl,
-          web_url: visibleService.serviceMetadata.webUrl
-        }
+      ? toApiServiceMetadata(visibleService.serviceMetadata)
       : undefined,
     service_name: visibleService.serviceName,
     version: visibleService.version

--- a/src/utils/service_metadata.ts
+++ b/src/utils/service_metadata.ts
@@ -1,0 +1,21 @@
+import { ServiceMetadata as ApiServiceMetadata } from "../../generated/definitions/ServiceMetadata";
+import { ServiceMetadata } from "../models/service";
+
+export const toApiServiceMetadata = (
+  serviceMetadata: ServiceMetadata
+): ApiServiceMetadata => ({
+  address: serviceMetadata.address,
+  app_android: serviceMetadata.appAndroid,
+  app_ios: serviceMetadata.appIos,
+  cta: serviceMetadata.cta,
+  description: serviceMetadata.description,
+  email: serviceMetadata.email,
+  pec: serviceMetadata.pec,
+  phone: serviceMetadata.phone,
+  privacy_url: serviceMetadata.privacyUrl,
+  scope: serviceMetadata.scope,
+  support_url: serviceMetadata.supportUrl,
+  token_name: serviceMetadata.tokenName,
+  tos_url: serviceMetadata.tosUrl,
+  web_url: serviceMetadata.webUrl
+});


### PR DESCRIPTION
This PR contains a refactoring of `ServiceMetadata` definition in order to add two new fields (e.g `cta`,  `token_name` and `support_url`). Moreover it is used to add a conversion utility for `ServiceMetadata` mapping and an attributes alignment between model and openapi specs.