### PR TITLE
[#175160851] Add VisibleServicePayload and HiddenServicePayload definitions

### DIFF
--- a/openapi/__tests__/definitions.test.ts
+++ b/openapi/__tests__/definitions.test.ts
@@ -1,0 +1,91 @@
+import { HiddenServicePayload } from "../../generated/definitions/HiddenServicePayload";
+import { ServicePayload } from "../../generated/definitions/ServicePayload";
+import { VisibleServicePayload } from "../../generated/definitions/VisibleServicePayload";
+
+describe("ServicePayload definition", () => {
+  const commonServicePayload = {
+    authorized_cidrs: [],
+    department_name: "Department Name",
+    organization_fiscal_code: "12345678901",
+    organization_name: "Organization Name",
+    require_secure_channels: true,
+    service_name: "Service Name",
+    version: 0
+  };
+
+  const visibleService = {
+    ...commonServicePayload,
+    is_visible: true,
+    service_metadata: {
+      address: "address",
+      app_android: "app",
+      app_ios: "app",
+      cta: "cta",
+      description: "Description",
+      email: "test@mail.it",
+      pec: "pec@mail.it",
+      phone: "333",
+      privacy_url: "http://privateurl.it",
+      scope: "LOCAL",
+      support_url: "http://supporturl.it",
+      token_name: "token",
+      tos_url: "http://weburlk.it",
+      web_url: "http://weburl.it"
+    }
+  };
+
+  const hiddenService = {
+    ...commonServicePayload,
+    is_visible: false
+  };
+
+  const invalidService = {
+    is_visible: true,
+    service_metadata: {
+      address: "address",
+      app_android: "app",
+      app_ios: "app",
+      cta: "cta",
+      description: "Description",
+      email: "test@mail.it",
+      pec: "pec@mail.it",
+      phone: "333",
+      privacy_url: "http://privateurl.it",
+      scope: "LOCAL",
+      support_url: "http://supporturl.it",
+      token_name: "token",
+      tos_url: "http://weburlk.it",
+      web_url: "http://weburl.it"
+    }
+  };
+
+  it("should decode visibleService with VisibleService and ServicePayload", () => {
+    const servicePayloadTest = ServicePayload.decode(visibleService);
+    const visibleServiceTest = VisibleServicePayload.decode(visibleService);
+    const hiddenServiceTest = HiddenServicePayload.decode(visibleService);
+
+    expect(servicePayloadTest.isRight()).toBe(true);
+    expect(visibleServiceTest.isRight()).toBe(true);
+    expect(hiddenServiceTest.isLeft()).toBe(true);
+  });
+
+  it("should decode hiddenService with HiddenService and ServicePayload", () => {
+    const servicePayloadTest = ServicePayload.decode(hiddenService);
+    const visibleServiceTest = VisibleServicePayload.decode(hiddenService);
+    const hiddenServiceTest = HiddenServicePayload.decode(hiddenService);
+
+    expect(servicePayloadTest.isRight()).toBe(true);
+    expect(visibleServiceTest.isLeft()).toBe(true);
+    expect(hiddenServiceTest.isRight()).toBe(true);
+  });
+
+  it("should not decode invalidService with HiddenService, ServicePayload and VisibleServicePayload", () => {
+    const servicePayloadTest = ServicePayload.decode(invalidService);
+    const visibleServiceTest = VisibleServicePayload.decode(invalidService);
+    const hiddenServiceTest = HiddenServicePayload.decode(invalidService);
+
+    expect(servicePayloadTest.isLeft()).toBe(true);
+    expect(visibleServiceTest.isLeft()).toBe(true);
+    expect(hiddenServiceTest.isLeft()).toBe(true);
+  });
+});

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -532,7 +532,7 @@ ServicePayload:
   x-one-of: true
   allOf:
    - $ref: "#/VisibleServicePayload"    
-   - $ref: "#/InvisibleServicePayload"
+   - $ref: "#/HiddenServicePayload"
 CommonServicePayload:
   description: Common properties for a ServicePayload
   type: object
@@ -573,14 +573,15 @@ VisibleServicePayload:
     properties:
       is_visible:
         type: boolean
-        enum: [ true ]
+        enum:
+          - true
         description: |-
           It indicates that service appears in the service list
       service_metadata:
         $ref: "#/ServiceMetadata"
   required:
     - service_metadata
-InvisibleServicePayload:
+HiddenServicePayload:
   description: A payload used to create/update a service that is hidden.
   allOf:
   - $ref: "#/CommonServicePayload"
@@ -589,7 +590,8 @@ InvisibleServicePayload:
       is_visible:
         type: boolean
         default: false
-        enum: [ false ]
+        enum:
+          - false
         description: |-
           It indicates that service is hidden
       service_metadata:

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -529,6 +529,11 @@ SenderMetadata:
     - department_name
 ServicePayload:
   description: A payload used to create/update a service for a user.
+  oneOf:
+   - $ref: "#/VisibleServicePayload"    
+   - $ref: "#/InvisibleServicePayload"
+CommonServicePayload:
+  description: Common properties for a ServicePayload
   type: object
   properties:
     service_name:
@@ -553,19 +558,41 @@ ServicePayload:
       default: false
       description: |-
         When true, messages won't trigger email notifications (only push).
-    is_visible:
-        type: boolean
-        default: false
-        description: |-
-          When true the service appears in the service list, otherwise is hidden.
-    service_metadata:
-      $ref: "#/ServiceMetadata"
   required:
     - service_name
     - department_name
     - organization_name
     - organization_fiscal_code
     - authorized_cidrs
+VisibleServicePayload:
+  description: A payload used to create/update a service that appears in the service list.
+  allOf:
+  - $ref: "#/CommonServicePayload"
+  - type: object
+    properties:
+      is_visible:
+        type: boolean
+        enum: [ true ]
+        description: |-
+          It indicates that service appears in the service list
+      service_metadata:
+        $ref: "#/ServiceMetadata"
+  required:
+    - service_metadata
+InvisibleServicePayload:
+  description: A payload used to create/update a service that is hidden.
+  allOf:
+  - $ref: "#/CommonServicePayload"
+  - type: object
+    properties:
+      is_visible:
+        type: boolean
+        default: false
+        enum: [ false ]
+        description: |-
+          It indicates that service is hidden
+      service_metadata:
+        $ref: "#/ServiceMetadata"
 Service: 
   description: A service tied to user's subscription.
   allOf:

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -529,7 +529,8 @@ SenderMetadata:
     - department_name
 ServicePayload:
   description: A payload used to create/update a service for a user.
-  oneOf:
+  x-one-of: true
+  allOf:
    - $ref: "#/VisibleServicePayload"    
    - $ref: "#/InvisibleServicePayload"
 CommonServicePayload:

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "danger": "^7.0.0",
     "danger-plugin-digitalcitizenship": "*",
     "italia-tslint-rules": "*",
-    "italia-utils": "^6.0.0",
+    "italia-utils": "^6.2.0",
     "jest": "^24.8.0",
     "prettier": "^1.14.3",
     "release-it": "^13.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3641,10 +3641,10 @@ italia-tslint-rules@*:
     tslint-sonarts "^1.9.0"
     typestrict "^1.0.2"
 
-italia-utils@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/italia-utils/-/italia-utils-6.0.0.tgz#f424d1e4077606aea444e6a6af101f107ff83675"
-  integrity sha512-p4n3953whfOmwQeE4yiyeW63QsdHrZXq3fGBIFhcHVAOT0wPdly8RA78nfjLgcEb6ZHccxDnARs8D4GcHdT38Q==
+italia-utils@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/italia-utils/-/italia-utils-6.2.0.tgz#1b7ec4cc14192efb69a4a69f19cc7bd570202a09"
+  integrity sha512-GAfQE2ws9NF/LzMGF+26lK4iCh3jeYjjfjc2XnTU68aQkaxbxbDR7zU4rr1XI0qQU+NT06q5/UIKMGBZq0j9SQ==
   dependencies:
     fs-extra "^6.0.0"
     italia-ts-commons "^5.0.1"


### PR DESCRIPTION
This PR introduces a new definition for `ServicePayload` in order to model the mandatory of service metadata for visible services.

So, the new `ServicePayload`  is valid against one of the following schema:

 - `VisibleServicePayload` 
 - `HiddenServicePayload`

These definitions differ only for the metadata property, which in the case of `VisibleServicePayload` is required.
