### PR TITLE
[#176013578] Use custom command to publish package

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -124,7 +124,8 @@ stages:
 
           - task: Npm@1
             inputs: 
-              command: publish
+              command: custom
+              customCommand: publish --access public
+              customEndpoint: $(NPM_CONNECTION)
               verbose: true
-              publishEndpoint: $(NPM_CONNECTION)
               workingDir: '$(Pipeline.Workspace)/Bundle'


### PR DESCRIPTION
Following the work of #129, I'm trying to get the package published.

In this PR I try to do it with a custom command instead of the built-in `publish` option. This is needed in order to instruct on the access level required by the package (`public`).

Since `io-functions-commons` is a scoped package, as by [npm docs](https://docs.npmjs.com/cli/v6/commands/npm-publish) the default access value is `restricted`. 

I also opened [an issue](https://github.com/microsoft/azure-pipelines-tasks/issues/14165) on the Azure task repo.