### PR TITLE
Test pipeline permissions from fork

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -45,17 +45,6 @@ stages:
   # - is on branch master 
   # - is a tag in the form v{version}-RELEASE
   - stage: Release
-    condition:
-      and(
-        succeeded(),
-        or(
-          eq(variables['Build.SourceBranch'], 'refs/heads/master'),
-          and(
-            startsWith(variables['Build.SourceBranch'], 'refs/tags'),
-            endsWith(variables['Build.SourceBranch'], '-RELEASE')
-          )
-        )
-      )
     jobs:
       - job: make_release
         steps:

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -24,7 +24,8 @@ parameters:
 
 # Only manual activations are intended
 trigger: none
-pr: none
+# I'm making a test: would it be triggered by the 
+# pr: none
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -122,10 +123,11 @@ stages:
           - download: current
             artifact: Bundle
 
-          - task: Npm@1
-            inputs: 
-              command: custom
-              customCommand: publish --access public
-              customEndpoint: $(NPM_CONNECTION)
-              verbose: true
-              workingDir: '$(Pipeline.Workspace)/Bundle'
+          # disable for testing
+          # - task: Npm@1
+            # inputs: 
+              #command: custom
+              #customCommand: publish --access public
+              #customEndpoint: $(NPM_CONNECTION)
+              #verbose: true
+              #workingDir: '$(Pipeline.Workspace)/Bundle'


### PR DESCRIPTION
Performing the very same test of https://github.com/pagopa/io-functions-commons/pull/132, but from a fork