### PR TITLE
[#ENTE-20] AuthorizedCIDRs without subnet

### DIFF
--- a/src/utils/__tests__/source_ip_check.test.ts
+++ b/src/utils/__tests__/source_ip_check.test.ts
@@ -1,13 +1,18 @@
 /* tslint:disable:no-identical-functions */
 
 import { ResponseSuccessJson } from "@pagopa/ts-commons/lib/responses";
-import { IPString } from "@pagopa/ts-commons/lib/strings";
+import { EmailString, IPString } from "@pagopa/ts-commons/lib/strings";
 import { ITuple2, Tuple2 } from "@pagopa/ts-commons/lib/tuples";
-import { toAuthorizedCIDRs } from "../../models/service";
+import { Service, toAuthorizedCIDRs } from "../../models/service";
 import { ClientIp } from "../middlewares/client_ip_middleware";
 
+import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
 import { fromEither as OptionFromEither } from "fp-ts/lib/Option";
-import { checkSourceIpForHandler } from "../source_ip_check";
+import { IAzureUserAttributes } from "../middlewares/azure_user_attributes";
+import {
+  checkSourceIpForHandler,
+  clientIPAndCidrTuple
+} from "../source_ip_check";
 
 describe("checkSourceIpForHandler", () => {
   // a sample request handler that gets the source IP and allowed CIDRs
@@ -57,5 +62,40 @@ describe("checkSourceIpForHandler", () => {
       toAuthorizedCIDRs(["192.168.1.0/24"])
     );
     expect(result.kind).toEqual("IResponseErrorForbiddenNotAuthorized");
+  });
+});
+
+describe("clientIPAndCidrTuple", () => {
+  const userAttributes: IAzureUserAttributes = {
+    email: "email@example.com" as EmailString,
+    kind: "IAzureUserAttributes",
+    service: ({
+      authorizedCIDRs: toAuthorizedCIDRs(["192.168.1.0/24"])
+    } as unknown) as Service & { readonly version: NonNegativeInteger }
+  };
+  const expectedClientIp = OptionFromEither(IPString.decode("192.168.10.10"));
+  it("should return a set with client ip and autorizedCIDRs", () => {
+    const resultTuple = clientIPAndCidrTuple(expectedClientIp, userAttributes);
+    expect(resultTuple.e1).toBe(expectedClientIp);
+    expect(resultTuple.e2).toStrictEqual(
+      userAttributes.service.authorizedCIDRs
+    );
+  });
+  it("should add /32 subnet if autorizedCIDR hasn't any subnet", () => {
+    const userAttributesNoSubnet: IAzureUserAttributes = {
+      email: "email@example.com" as EmailString,
+      kind: "IAzureUserAttributes",
+      service: ({
+        authorizedCIDRs: toAuthorizedCIDRs(["192.168.1.0", "192.168.1.1/24"])
+      } as unknown) as Service & { readonly version: NonNegativeInteger }
+    };
+    const resultTuple = clientIPAndCidrTuple(
+      expectedClientIp,
+      userAttributesNoSubnet
+    );
+    expect(resultTuple.e1).toBe(expectedClientIp);
+    expect(resultTuple.e2).toStrictEqual(
+      toAuthorizedCIDRs(["192.168.1.0/32", "192.168.1.1/24"])
+    );
   });
 });

--- a/src/utils/source_ip_check.ts
+++ b/src/utils/source_ip_check.ts
@@ -16,6 +16,7 @@ import {
   ResponseErrorForbiddenNotAuthorized,
   ResponseErrorInternal
 } from "@pagopa/ts-commons/lib/responses";
+import { toAuthorizedCIDRs } from "../models/service";
 
 /**
  * Whether IP is contained in the provided CIDRs
@@ -162,5 +163,12 @@ export function clientIPAndCidrTuple(
   clientIp: ClientIp,
   userAttributes: IAzureUserAttributes
 ): ITuple2<ClientIp, ReadonlySet<string>> {
-  return Tuple2(clientIp, userAttributes.service.authorizedCIDRs);
+  return Tuple2(
+    clientIp,
+    toAuthorizedCIDRs(
+      Array.from(userAttributes.service.authorizedCIDRs).map(c =>
+        c.indexOf("/") !== -1 ? c : `${c}/32`
+      )
+    )
+  );
 }

--- a/src/utils/source_ip_check.ts
+++ b/src/utils/source_ip_check.ts
@@ -16,6 +16,7 @@ import {
   ResponseErrorForbiddenNotAuthorized,
   ResponseErrorInternal
 } from "@pagopa/ts-commons/lib/responses";
+import { CIDR } from "../../generated/definitions/CIDR";
 import { toAuthorizedCIDRs } from "../models/service";
 
 /**
@@ -163,12 +164,15 @@ export function clientIPAndCidrTuple(
   clientIp: ClientIp,
   userAttributes: IAzureUserAttributes
 ): ITuple2<ClientIp, ReadonlySet<string>> {
+  /**
+   * Add the default /32 subnet to an IP without any subnet.
+   */
+  const withDefaultSubnet = (ip: CIDR): CIDR =>
+    ip.indexOf("/") !== -1 ? ip : (`${ip}/32` as CIDR);
   return Tuple2(
     clientIp,
     toAuthorizedCIDRs(
-      Array.from(userAttributes.service.authorizedCIDRs).map(c =>
-        c.indexOf("/") !== -1 ? c : `${c}/32`
-      )
+      Array.from(userAttributes.service.authorizedCIDRs).map(withDefaultSubnet)
     )
   );
 }


### PR DESCRIPTION
#### List of Changes
- `authorizedCIDRs` without subnet has default `\32` subnet.

#### Motivation and Context
When a Service has an authorized CIDR without a subnet the IPChek fail. This PR adds a default `\32` subnet.

#### How Has This Been Tested?
- unit test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
