### PR TITLE
[#IP-82] Add a response header containing the current app version

### DIFF
--- a/src/utils/express.ts
+++ b/src/utils/express.ts
@@ -1,4 +1,5 @@
 import * as express from "express";
+import { toString } from "fp-ts/lib/function";
 import * as helmet from "helmet";
 import * as csp from "helmet-csp";
 import * as referrerPolicy from "referrer-policy";
@@ -39,4 +40,26 @@ export function secureExpressApp(app: express.Express): void {
       }
     })
   );
+}
+
+/**
+ * Create an express middleware to set the 'X-API-Version' response header field containing the current app version in execution (from the npm environment).
+ * @returns a factory method for the Middleware
+ */
+const createAppVersionHeaderHandler: () => express.RequestHandler = () => (
+  _,
+  res,
+  next
+) => {
+  res.setHeader("X-API-Version", toString(process.env.npm_package_version));
+  next();
+};
+
+/**
+ * Configure all the default express middleware handlers on the input express app.
+ * Register here all the non business-logic-related common behaviours.
+ * @param app an express application
+ */
+export function configureDefaultHandlers(app: express.Express): void {
+  app.use(createAppVersionHeaderHandler());
 }

--- a/src/utils/express.ts
+++ b/src/utils/express.ts
@@ -43,7 +43,7 @@ export function secureExpressApp(app: express.Express): void {
 }
 
 /**
- * Create an express middleware to set the 'X-API-Version' response header field containing the current app version in execution (from the npm environment).
+ * Create an express middleware to set the 'X-API-Version' response header field to the current app version in execution (from the npm environment).
  * @returns a factory method for the Middleware
  */
 const createAppVersionHeaderHandler: () => express.RequestHandler = () => (


### PR DESCRIPTION
In order to ease the troubleshooting, we want to add to all the service response a new header field (X-API-Version) containing the current app version.
We created a middleware setting the response header and a common register function to call from all the service code.
Both those functions have been implemented in this project to match the DRY principle and to ease the future similar task.