### PR TITLE
[#IP-163] Include OpenAPI spec file in package

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -105,6 +105,7 @@ stages:
                 CHANGELOG.md
                 package.json
                 dist/**/*
+                openapi/**/*.(yaml|yml)
             displayName: 'Copy bundle files'
           
           - publish: $(System.DefaultWorkingDirectory)/bundle

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "https://www.pagopa.gov.it",
   "license": "MIT",
   "files": [
-    "dist/"
+    "dist/",
+    "openapi/*.(yaml|yml)"
   ],
   "scripts": {
     "prebuild": "rimraf dist",


### PR DESCRIPTION
Include OpenAPI definitions in published package so that they can be used by its dependents, if in need.

**Expected usage**
```yaml
Foo:
  $ref: "./node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#Foo"
```
