### PR TITLE
[#IP-203] Add message payload for EU Covid Certificate

### DIFF
--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -110,6 +110,6 @@ stages:
               COSMOSDB_URI=https://localhost:3000/ \
               COSMOSDB_KEY="dummy key" \
               COSMOSDB_DATABASE_NAME=integration-tests \
-              STORAGE_CONN_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1; \
+              STORAGE_CONN_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;" \
               yarn test:integration
             displayName: 'Integrations tests exec'

--- a/.devops/code-review-pipelines.yml
+++ b/.devops/code-review-pipelines.yml
@@ -93,7 +93,7 @@ stages:
           - template: azure-templates/setup-project.yml
 
           - bash: |
-              docker run -d -p 1025:1025 -p 8025:8025 --name mailhog mailhog/mailhog
+              docker run -d -p 1025:1025 -p 8025:8025 --name mailhog --rm mailhog/mailhog
             displayName: 'Start mailhog'
 
           - bash: |
@@ -102,9 +102,14 @@ stages:
             displayName: 'Start mock CosmosDB'
 
           - bash: |
+              docker run -d --rm -p 10000:10000 mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0
+            displayName: 'Start mock Azure Storage'
+
+          - bash: |
               MAILHOG_HOSTNAME=localhost \
               COSMOSDB_URI=https://localhost:3000/ \
               COSMOSDB_KEY="dummy key" \
               COSMOSDB_DATABASE_NAME=integration-tests \
+              STORAGE_CONN_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1; \
               yarn test:integration
             displayName: 'Integrations tests exec'

--- a/__integrations__/models/message.test.ts
+++ b/__integrations__/models/message.test.ts
@@ -56,6 +56,14 @@ const aMessageContentPrescription = {
   }
 };
 
+const aMessageContentEUCovidCert = {
+  subject: "a".repeat(20),
+  markdown: "a".repeat(100),
+  eu_covid_cert: {
+    auth_code: "a".repeat(25)
+  }
+};
+
 const aMessageContentWithNoPayment = {
   subject: "a".repeat(20),
   markdown: "a".repeat(100)
@@ -174,10 +182,11 @@ describe("Models |> Message", () => {
   });
 
   it.each`
-    title                                      | value
-    ${"a message content without"}             | ${aMessageContentWithNoPayment}
-    ${"a message content with payment data"}   | ${aMessageContentWithPayment}
-    ${"a message content with a prescription"} | ${aMessageContentPrescription}
+    title                                                        | value
+    ${"a message content without"}                               | ${aMessageContentWithNoPayment}
+    ${"a message content with payment data"}                     | ${aMessageContentWithPayment}
+    ${"a message content with a prescription"}                   | ${aMessageContentPrescription}
+    ${"a message content with a EU Covid Certificate auth code"} | ${aMessageContentEUCovidCert}
   `("should save $title correctly", async ({ value }) => {
     const context = await createContext(MESSAGE_MODEL_PK_FIELD, true);
     await context.init();
@@ -223,6 +232,9 @@ describe("Models |> Message", () => {
           );
           expect(result.prescription_data?.prescriber_fiscal_code).toEqual(
             value.prescription_data?.prescriber_fiscal_code
+          );
+          expect(result.eu_covid_cert?.auth_code).toEqual(
+            value.eu_covid_cert?.auth_code
           );
         }
       )

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -90,6 +90,8 @@ MessageContent:
       $ref: "#/PaymentData"
     prescription_data:
       $ref: "#/PrescriptionData"
+    eu_covid_cert:
+      $ref: "#/EUCovidCert"
     due_date:
       $ref: "#/Timestamp"
   required:
@@ -121,6 +123,15 @@ PrescriptionData:
       $ref: "#/PrescriberFiscalCode"
   required:
     - nre
+EUCovidCert:
+  type: object
+  description: |-
+    Paylod with access token to retrieve a EU Covid Certificate
+  properties:
+    auth_code:
+      type: string
+  required:
+    - auth_code
 PrescriptionIUP:
   description: The field *Identificativo Unico di Prescrizione* identifies the medical prescription at regional level.
   type: string


### PR DESCRIPTION
Allow a `Message` to accept a `eu_covid_cert` field in its content. 
An example of value could be:
```json
"eu_covid_cert": {
  "auth_code": "nk34nidwew9o4nro3noionwow"
}
```

Which will be included in a `Message` as 
```json
{
  "content": {
    "subject": "Certificato Europeo Covid-19",
    "markdown": "Visualizzare il tuo Certificato Europeo Covid-19. Per visualizzare il certificato è necessario aver installato l'ultiva versione dell'App IO.",
    "eu_covid_cert": {
      "auth_code": "nk34nidwew9o4nro3noionwow"
    }
  },
  "fiscal_code": "AAAAAA00A00A000A"
}
```