### PR TITLE
[#IP-223] Removed io-functions-express from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "fp-ts": "1.17.4",
     "helmet": "^4.5.0",
     "helmet-csp": "^2.5.1",
-    "io-functions-express": "^1.1.0",
     "io-ts": "1.8.5",
     "node-fetch": "^2.6.1",
     "nodemailer": "^6.4.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3999,11 +3999,6 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
-io-functions-express@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/io-functions-express/-/io-functions-express-1.1.2.tgz#3025242c2096e443a889c7eb8cb7555fb7f1e5c6"
-  integrity sha512-Gy+g5QQ7k+WnG9TpbgHXObIKrIj05iY/0uK86k+rTyTg6JF9YXVWCnKKmxX2LsJqLpWQtdwOQSwRQhNSfs/rxg==
-
 io-ts@1.8.5:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-1.8.5.tgz#2e102f7f518abe17b0f7e7ede0db54a4c4ddc188"


### PR DESCRIPTION
#### List of Changes
- Removed io-functions-express from dependencies

#### Motivation and Context
We want to keep dependencies updated and coherent between projects.
This dependency was not used and was causing cross-repo conflicts.

#### How Has This Been Tested?
It has been tested by performing:
- yarn install --frozen-lockfile
- yarn build
- yarn lint
- yarn test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.