### PR TITLE
Bugfix missing LEGACY preferences mode

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
+<!--- Even if we are all from our internal team, we may not be on the same page. -->
+<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
+<!--- This will improve our projects in the long run! Thanks. -->
+
+#### List of Changes
+<!--- Describe your changes in detail -->
+
+#### Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+#### How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, tests ran to see how -->
+<!--- your change affects other areas of the code, etc. -->
+
+#### Screenshots (if appropriate):
+
+#### Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Chore (nothing changes by a user perspective)
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+#### Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -841,15 +841,12 @@ ServicePreferencesSettings:
   properties:
     mode:
       $ref: "#/ServicesPreferencesMode"
-    version:
-      type: integer
-      minimum: 0
   required:
     - mode
-    - version
 ServicesPreferencesMode:
   type: string
   enum:
+    - LEGACY
     - AUTO
     - MANUAL
 ServicePreference:

--- a/src/models/__tests__/profile.test.ts
+++ b/src/models/__tests__/profile.test.ts
@@ -9,7 +9,6 @@ import { Profile, ProfileModel, RetrievedProfile } from "../profile";
 
 import { Container } from "@azure/cosmos";
 import { ServicesPreferencesModeEnum } from "../../../generated/definitions/ServicesPreferencesMode";
-import { version } from "process";
 
 const aFiscalCode = "FRLFRC74E04B157I" as FiscalCode;
 
@@ -61,7 +60,7 @@ describe("findLastVersionByModelId", () => {
         isEmailEnabled: true,
         isTestProfile: false,
         servicePreferencesSettings: {
-          mode: ServicesPreferencesModeEnum.AUTO,
+          mode: ServicesPreferencesModeEnum.LEGACY,
           version: 0
         }
       });

--- a/src/models/__tests__/profile.test.ts
+++ b/src/models/__tests__/profile.test.ts
@@ -12,13 +12,15 @@ import { ServicesPreferencesModeEnum } from "../../../generated/definitions/Serv
 
 const aFiscalCode = "FRLFRC74E04B157I" as FiscalCode;
 
-const aStoredProfile: Profile = Profile.decode({
+const aRawProfile = {
   acceptedTosVersion: 1,
   fiscalCode: aFiscalCode,
   isEmailValidated: false,
   isInboxEnabled: false,
   isWebhookEnabled: false
-}).getOrElseL(_ =>
+};
+
+const aStoredProfile: Profile = Profile.decode(aRawProfile).getOrElseL(_ =>
   fail(`Cannot decode aStoredProfile, error: ${readableReport(_)}`)
 );
 
@@ -112,6 +114,27 @@ describe("findLastVersionByModelId", () => {
     expect(isLeft(result)).toBeTruthy();
     if (isLeft(result)) {
       expect(result.value.kind).toBe("COSMOS_DECODING_ERROR");
+    }
+  });
+});
+
+describe("Profile codec", () => {
+  it("should consider all possible ServicesPreferencesMode values", async () => {
+    // This is a safe-guard to programmatically ensure all possible values of ServicesPreferencesModeEnum are considered
+
+    expect.assertions(0);
+    for (const mode in ServicesPreferencesModeEnum) {
+      const version = mode === "LEGACY" ? 0 : 1;
+      Profile.decode({
+        ...aRawProfile,
+        servicePreferencesSettings: { mode, version }
+      }).getOrElseL(_ =>
+        fail(
+          `Cannot decode profile, maybe an unhandled ServicesPreferencesMode: ${mode}, error: ${readableReport(
+            _
+          )}`
+        )
+      );
     }
   });
 });

--- a/src/models/__tests__/profile.test.ts
+++ b/src/models/__tests__/profile.test.ts
@@ -122,7 +122,6 @@ describe("Profile codec", () => {
   it("should consider all possible ServicesPreferencesMode values", async () => {
     // This is a safe-guard to programmatically ensure all possible values of ServicesPreferencesModeEnum are considered
 
-    expect.assertions(0);
     for (const mode in ServicesPreferencesModeEnum) {
       const version = mode === "LEGACY" ? 0 : 1;
       Profile.decode({


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
* introduce `LEGACY` preferences mode to map Profiles with old schema in [`99b10ab` (#185)](https://github.com/pagopa/io-functions-commons/pull/185/commits/99b10ab078ea862a8b6e3a5c81cecb03525f1d5c)
* test all modes are considered in [`ddeaee8` (#185)](https://github.com/pagopa/io-functions-commons/pull/185/commits/ddeaee8572f735f09f4d808219a5dbbb8865949b)
* add integration tests for negative scenarios in [`6b67655` (#185)](https://github.com/pagopa/io-functions-commons/pull/185/commits/6b67655825cea1b2474dc3c976bf900e86332eff)
* (chore) add PR template in [`5fc1af5` (#185)](https://github.com/pagopa/io-functions-commons/pull/185/commits/5fc1af519b1fcc3f55fc384a95f4044736459575)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We recognized we need an explicit definition for Citizens whose `Profile` hasn't switched to new preferences mechanism yet.
By doing so, we also realized we no longer need to pass `version` back and forth to clients, as it can be handled as an internal value by the model; hence, we removed such value from api definitions in https://github.com/pagopa/io-functions-commons/pull/185/commits/99b10ab078ea862a8b6e3a5c81cecb03525f1d5c).
We also constrained the set of possible values to be assigned, by enforcing `version=0` to be allowed only with `mode=LEGACY` and viceversa.

On the other hand, to handle `version` increment correctly is still a responsibility to the controller interacting with `Profile` model. 
 
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
With integration tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
