### PR TITLE
[#ENTE-79] listLastVersionServices in Service model

### DIFF
--- a/src/models/__tests__/service.test.ts
+++ b/src/models/__tests__/service.test.ts
@@ -134,9 +134,9 @@ describe("listLastVersionServices", () => {
 
     const result = await model.listLastVersionServices()();
     expect(E.isRight(result)).toBeTruthy();
-    if (E.isRight(result) && O.isSome(result.right)) {
-      expect(result.right.value).toHaveLength(2);
-      expect(result.right.value).toMatchObject([expectedService, anotherService]);
+    if (E.isRight(result)) {
+      expect(O.toUndefined(result.right)).toHaveLength(2);
+      expect(O.toUndefined(result.right)).toMatchObject([expectedService, anotherService]);
     }
   });
   it("should resolve to an empty value if no service is found", async () => {

--- a/src/models/__tests__/service.test.ts
+++ b/src/models/__tests__/service.test.ts
@@ -72,9 +72,8 @@ describe("findOneServiceById", () => {
     expect(E.isRight(result)).toBeTruthy();
     if (E.isRight(result)) {
       expect(O.isSome(result.right)).toBeTruthy();
-      // use JSON.stringify because of a jest matcher bug ref. https://github.com/facebook/jest/issues/8475
-      expect(JSON.stringify(O.toUndefined(result.right))).toEqual(
-        JSON.stringify(aRetrievedService)
+      expect(O.toUndefined(result.right)).toMatchObject(
+        aRetrievedService
       );
     }
   });
@@ -133,13 +132,11 @@ describe("listLastVersionServices", () => {
     mockGetAsyncIterator.mockReturnValueOnce(asyncIterable);
     const model = new ServiceModel(containerMock);
 
-    const result = await model.listLastVersionServices().run();
-    expect(isRight(result)).toBeTruthy();
-    if (isRight(result)) {
-      expect(result.value.isSome()).toBeTruthy();
-      // use JSON.stringify because of a jest matcher bug ref. https://github.com/facebook/jest/issues/8475
-      expect(result.value.toUndefined()).toHaveLength(2);
-      expect(JSON.stringify(result.value.toUndefined())).toEqual(JSON.stringify([expectedService, anotherService]));
+    const result = await model.listLastVersionServices()();
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result) && O.isSome(result.right)) {
+      expect(result.right.value).toHaveLength(2);
+      expect(result.right.value).toMatchObject([expectedService, anotherService]);
     }
   });
   it("should resolve to an empty value if no service is found", async () => {
@@ -148,11 +145,11 @@ describe("listLastVersionServices", () => {
 
     const model = new ServiceModel(containerMock);
 
-    const result = await model.listLastVersionServices().run();
+    const result = await model.listLastVersionServices()();
 
-    expect(isRight(result)).toBeTruthy();
-    if (isRight(result)) {
-      expect(result.value.isNone()).toBeTruthy();
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result)) {
+      expect(O.isNone(result.right)).toBeTruthy();
     }
   });
   it("should validate the retrieved object agains the model type", async () => {
@@ -161,11 +158,11 @@ describe("listLastVersionServices", () => {
 
     const model = new ServiceModel(containerMock);
 
-    const result = await model.listLastVersionServices().run();
+    const result = await model.listLastVersionServices()();
 
-    expect(isLeft(result)).toBeTruthy();
-    if (isLeft(result)) {
-      expect(result.value.kind).toBe("COSMOS_DECODING_ERROR");
+    expect(E.isLeft(result)).toBeTruthy();
+    if (E.isLeft(result)) {
+      expect(result.left.kind).toBe("COSMOS_DECODING_ERROR");
     }
   });
 });

--- a/src/models/__tests__/service.test.ts
+++ b/src/models/__tests__/service.test.ts
@@ -117,7 +117,7 @@ describe("findOneServiceById", () => {
 const getAsyncIterable = <T>(pages: ReadonlyArray<ReadonlyArray<T>>) =>
   ({
     [Symbol.asyncIterator]: async function* asyncGenerator() {
-      var array = pages.map(_ => Promise.resolve(_));
+      let array = pages.map(_ => Promise.resolve(_));
       while (array.length) {
         yield {resources: await array.shift()};
       }

--- a/src/models/service.ts
+++ b/src/models/service.ts
@@ -270,6 +270,10 @@ export class ServiceModel extends CosmosdbModelVersioned<
                 .decode(_.value)
                 .map(services =>
                   some(
+                    // Remap an array of services to a Record with serviceId as key and
+                    // the entire service as value, the value is updated only if the
+                    // processing service is a newer version.
+                    // From that Record we keep only the values (last version of each service).
                     Object.values(
                       services.reduce((prev, curr) => {
                         const isNewer =

--- a/src/models/service.ts
+++ b/src/models/service.ts
@@ -263,30 +263,28 @@ export class ServiceModel extends CosmosdbModelVersioned<
     )
       .map(_ => fromNullable(_.resources))
       .chain(_ =>
-        _.isSome()
-          ? _.value.length > 0
-            ? fromEither(
-                t
-                  .readonlyArray(this.retrievedItemT)
-                  .decode(_.value)
-                  .map(services =>
-                    some(
-                      Object.values(
-                        services.reduce((prev, curr) => {
-                          const isNewer =
-                            !prev[curr.serviceId] ||
-                            curr.version > prev[curr.serviceId].version;
-                          return {
-                            ...prev,
-                            ...(isNewer ? { [curr.serviceId]: curr } : {})
-                          };
-                        }, {} as Record<string, RetrievedService>)
-                      )
+        _.isSome() && _.value.length > 0
+          ? fromEither(
+              t
+                .readonlyArray(this.retrievedItemT)
+                .decode(_.value)
+                .map(services =>
+                  some(
+                    Object.values(
+                      services.reduce((prev, curr) => {
+                        const isNewer =
+                          !prev[curr.serviceId] ||
+                          curr.version > prev[curr.serviceId].version;
+                        return {
+                          ...prev,
+                          ...(isNewer ? { [curr.serviceId]: curr } : {})
+                        };
+                      }, {} as Record<string, RetrievedService>)
                     )
                   )
-                  .mapLeft(CosmosDecodingError)
-              )
-            : fromEither(right(none))
+                )
+                .mapLeft(CosmosDecodingError)
+            )
           : fromEither(right(none))
       );
   }

--- a/src/models/service.ts
+++ b/src/models/service.ts
@@ -17,9 +17,10 @@ import {
   readonlySetType,
   withDefault
 } from "@pagopa/ts-commons/lib/types";
-import { fromEither, taskEither, TaskEither } from "fp-ts/lib/TaskEither";
-import { isLeft, right } from "fp-ts/lib/Either";
-import { tryCatch } from "fp-ts/lib/TaskEither";
+import * as TE from "fp-ts/lib/TaskEither";
+import { isRight } from "fp-ts/lib/Either";
+import { pipe } from "fp-ts/lib/function";
+import { Tuple2 } from "@pagopa/ts-commons/lib/tuples";
 import { CIDR } from "../../generated/definitions/CIDR";
 import {
   CosmosdbModelVersioned,
@@ -247,46 +248,58 @@ export class ServiceModel extends CosmosdbModelVersioned<
    */
   public findOneByServiceId(
     serviceId: NonEmptyString
-  ): TaskEither<CosmosErrors, Option<RetrievedService>> {
+  ): TE.TaskEither<CosmosErrors, Option<RetrievedService>> {
     return super.findLastVersionByModelId([serviceId]);
   }
 
-  public listLastVersionServices(): TaskEither<
+  public listLastVersionServices(): TE.TaskEither<
     CosmosErrors,
     Option<ReadonlyArray<RetrievedService>>
   > {
-    return tryCatch(
-      () =>
-        // Reduce all the services to a Record with serviceId as key
-        // and the last version of the service as value.
-        reduceAsyncIterator(
-          mapAsyncIterable(this.getCollectionIterator(), _ => {
-            if (_.some(isLeft)) {
-              throw _.filter(isLeft)[0].value;
-            }
-            return _.map(s => s.value) as ReadonlyArray<RetrievedService>;
-          })[Symbol.asyncIterator](),
-          (prev, curr) => {
-            // Reducer function
-            const isNewer =
-              !prev[curr.serviceId] ||
-              curr.version > prev[curr.serviceId].version;
-            return {
-              ...prev,
-              ...(isNewer ? { [curr.serviceId]: curr } : {})
-            };
-          },
-          {} as Record<string, RetrievedService>
-        ),
-      err => CosmosDecodingError(err as t.Errors)
-    ).chain(servicesMap => {
-      // Receive a Record with serviceId as key and
-      // the last version service as value.
-      // From that Record we keep only the values.
-      const services = Object.values(servicesMap);
-      return services.length > 0
-        ? taskEither.of(some(services))
-        : fromEither(right(none));
-    });
+    return pipe(
+      TE.tryCatch<CosmosErrors, Record<string, RetrievedService>>(
+        () =>
+          // Reduce all the services to a Record with serviceId as key
+          // and the last version of the service as value.
+          reduceAsyncIterator(
+            mapAsyncIterable(this.getCollectionIterator(), _ => {
+              const elementSelector = _.reduce((acc, el) => {
+                if (isRight(el)) {
+                  return Tuple2([...acc.e1, el.right], acc.e2);
+                }
+                return Tuple2(acc.e1, [...acc.e2, el.left]);
+              }, Tuple2<ReadonlyArray<RetrievedService>, ReadonlyArray<t.Errors>>([], []));
+              if (elementSelector.e2.length > 0) {
+                // If at least one element is left we throw the first error
+                throw elementSelector.e2[0];
+              }
+              return elementSelector.e1;
+            })[Symbol.asyncIterator](),
+            (prev, curr) => {
+              // Reducer function
+              const isNewer =
+                !prev[curr.serviceId] ||
+                curr.version > prev[curr.serviceId].version;
+              return {
+                ...prev,
+                ...(isNewer ? { [curr.serviceId]: curr } : {})
+              };
+            },
+            {} as Record<string, RetrievedService>
+          ),
+        err => CosmosDecodingError(err as t.Errors)
+      ),
+      TE.chain<
+        CosmosErrors,
+        Record<string, RetrievedService>,
+        Option<ReadonlyArray<RetrievedService>>
+      >(servicesMap => {
+        // Receive a Record with serviceId as key and
+        // the last version service as value.
+        // From that Record we keep only the values.
+        const services = Object.values(servicesMap);
+        return services.length > 0 ? TE.of(some(services)) : TE.of(none);
+      })
+    );
   }
 }

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -143,3 +143,34 @@ export const flattenAsyncIterable = <T>(
       flattenAsyncIterator(iter)
   };
 };
+
+/**
+ * Reduces over an AsyncIterator
+ *
+ * @param iter The iterator we want to reduce
+ * @param f The reducer function
+ * @param a It is used as the initial value to start the accumulation.
+ */
+export const reduceAsyncIterator = async <T, V>(
+  iter: AsyncIterator<ReadonlyArray<T>>,
+  f: (p: V, t: T) => V,
+  a: V
+): Promise<V> => {
+  // eslint-disable-next-line functional/no-let
+  let acc = a;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const {
+      done,
+      value
+    }: {
+      readonly done?: boolean;
+      readonly value: ReadonlyArray<T>;
+    } = await iter.next();
+    if (done) {
+      return value ? value.reduce(f, acc) : acc;
+    }
+    // eslint-disable-next-line functional/immutable-data
+    acc = value.reduce(f, acc);
+  }
+};


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add new method `listLastVersionServices` in `Service` model to get the last version of all services in cosmos

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To generate services webview and services list into the IO website we need do retrieve all the services from cosmos.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

