### PR TITLE
Add `DecodedFeedResponse` type definition

### DIFF
--- a/src/utils/cosmosdb_model.ts
+++ b/src/utils/cosmosdb_model.ts
@@ -142,6 +142,18 @@ const wrapCreate = <TN, TR>(
 };
 
 /**
+ * Define a FeedResponse in which the type fof the resource is strictly enforced through validation
+ */
+export type DecodedFeedResponse<TResource> = ReadonlyArray<
+  {
+    readonly resource: t.Validation<TResource>;
+  } & (
+    | { readonly hasMoreResults: true; readonly continuationToken: string }
+    | { readonly hasMoreResults: false; readonly continuationToken: undefined }
+  )
+>;
+
+/**
  * A persisted data model backed by a CosmosDB client: this base class
  * abstracts the semantics of the CosmosDB API, by providing the shared code
  * for persisting, retrieving and updating a document model.


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When dealing with a query with more than a result, we need to get access to results' metadata such as `hasMoreResults` and `continuationToken`. Cosmosdb's SDK provide such informations in its [`FeedResponse` response object](https://github.com/Azure/azure-sdk-for-js/blob/e823b26f4600a698eb1c06f48da9b780fb2331a7/sdk/cosmosdb/cosmos/src/request/FeedResponse.ts#L6); so far, we decided to strip metadata off the results, so to have a cleaner data structure (see [here](https://github.com/pagopa/io-functions-commons/blob/0785e81b4aba3e00e37936cacba5305b133cdc08/src/utils/cosmosdb_model.ts#L261)).

We are now going back on this decision, having query results to come with their metadata. `DecodedFeedResponse` is an interface that mimics `FeedResponse` in naming, but adds a couple of features:
* resources type is enforced through validation
* the result set is an array, thus more convenient to handle in map/reduce pipelines (just as it is now)
* consistency between `hasMoreResults` and `continuationToken` in enforced, that is we have no `continuationToken` when `hasMoreResults=false` and viceversa

The introduced interface is not implemented yet.

##### Usage
```ts
public getQueryIterator(
    query: string | SqlQuerySpec,
    options?: FeedOptions
  ): AsyncIterable<DecodedFeedResponse<TR>> {
    const iterator = this.container.items
      .query(query, options)
      .getAsyncIterator();
    return mapAsyncIterable(iterator, feedResponse =>
      feedResponse.resources.map(e => ({
        ...(typeof feedResponse.continuationToken === "string"
          ? {
              continuationToken: feedResponse.continuationToken,
              hasMoreResults: true
            }
          : { continuationToken: undefined, hasMoreResults: false }),
        resource: this.retrievedItemT.decode(e)
      }))
    );
  }
```

#### List of Changes
<!--- Describe your changes in detail -->
* Add `DecodedFeedResponse` type definition

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The definition hasn't been used yet

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
