### PR TITLE
[#IP-405] Fixed messages query to use index

### DIFF
--- a/__integrations__/models/message.test.ts
+++ b/__integrations__/models/message.test.ts
@@ -18,6 +18,7 @@ import { CosmosErrors } from "../../src/utils/cosmosdb_model";
 import { Validation } from "io-ts";
 import * as E from "fp-ts/lib/Either";
 import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
+import { IndexingPolicy } from "@azure/cosmos";
 
 const MESSAGE_CONTAINER_NAME = "test-message-container" as NonEmptyString;
 
@@ -86,10 +87,25 @@ const asyncIteratorToPageOfResults = <T>(source: AsyncIterator<T>) => {
   return source.next().then(ir => ir.value as T);
 };
 
+const messagesIndexingPolicy = {
+  compositeIndexes: [
+    [
+      {
+        path: "/fiscalCode",
+        order: "ascending"
+      },
+      {
+        path: "/id",
+        order: "descending"
+      }
+    ]
+  ]
+} as IndexingPolicy;
+
 describe("Models |> Message", () => {
   it("should save messages without content", async () => {
     const context = await createContext(MESSAGE_MODEL_PK_FIELD);
-    await context.init();
+    await context.init(messagesIndexingPolicy);
     const model = new MessageModel(context.container, MESSAGE_CONTAINER_NAME);
 
     // create a new document
@@ -192,7 +208,7 @@ describe("Models |> Message", () => {
     ${"a message content with a EU Covid Certificate auth code"} | ${aMessageContentEUCovidCert}
   `("should save $title correctly", async ({ value }) => {
     const context = await createContext(MESSAGE_MODEL_PK_FIELD, true);
-    await context.init();
+    await context.init(messagesIndexingPolicy);
     const model = new MessageModel(
       context.container,
       context.containerName as NonEmptyString
@@ -250,7 +266,7 @@ describe("Models |> Message", () => {
 
   it("should retrieve a page with all messages when they are less than default page size and no parameter is passed to query", async () => {
     const context = await createContext(MESSAGE_MODEL_PK_FIELD);
-    await context.init();
+    await context.init(messagesIndexingPolicy);
     const model = new MessageModel(context.container, MESSAGE_CONTAINER_NAME);
 
     // create 20 messages
@@ -286,7 +302,7 @@ describe("Models |> Message", () => {
 
   it("should have a done iterator after all results have been given", async () => {
     const context = await createContext(MESSAGE_MODEL_PK_FIELD);
-    await context.init();
+    await context.init(messagesIndexingPolicy);
     const model = new MessageModel(context.container, MESSAGE_CONTAINER_NAME);
 
     // create 20 messages
@@ -325,7 +341,7 @@ describe("Models |> Message", () => {
 
   it("should retrieve a page of maximum default page size number of records when no parameter is passed to query", async () => {
     const context = await createContext(MESSAGE_MODEL_PK_FIELD);
-    await context.init();
+    await context.init(messagesIndexingPolicy);
     const model = new MessageModel(context.container, MESSAGE_CONTAINER_NAME);
 
     // create 10 messages more than defaultPageSize
@@ -361,7 +377,7 @@ describe("Models |> Message", () => {
 
   it("should retrieve a page with all ids greater than minimumId", async () => {
     const context = await createContext(MESSAGE_MODEL_PK_FIELD);
-    await context.init();
+    await context.init(messagesIndexingPolicy);
     const model = new MessageModel(context.container, MESSAGE_CONTAINER_NAME);
 
     // create some messages
@@ -401,7 +417,7 @@ describe("Models |> Message", () => {
 
   it("should retrieve a page with all ids smaller than maximumId", async () => {
     const context = await createContext(MESSAGE_MODEL_PK_FIELD);
-    await context.init();
+    await context.init(messagesIndexingPolicy);
     const model = new MessageModel(context.container, MESSAGE_CONTAINER_NAME);
 
     // create some messages
@@ -441,7 +457,7 @@ describe("Models |> Message", () => {
 
   it("should correctly keep a descending order", async () => {
     const context = await createContext(MESSAGE_MODEL_PK_FIELD);
-    await context.init();
+    await context.init(messagesIndexingPolicy);
     const model = new MessageModel(context.container, MESSAGE_CONTAINER_NAME);
 
     // create some messages

--- a/src/models/__tests__/message.test.ts
+++ b/src/models/__tests__/message.test.ts
@@ -189,7 +189,7 @@ it("should return an iterator containing results page of correct pageSize", asyn
       parameters: [
         { name: "@fiscalCode", value: aRetrievedMessageWithContent.fiscalCode }
       ],
-      query: "SELECT * FROM m WHERE m.fiscalCode = @fiscalCode ORDER BY m.id DESC"
+      query: "SELECT * FROM m WHERE m.fiscalCode = @fiscalCode ORDER BY m.fiscalCode, m.id DESC"
     },
     { maxItemCount: 2 }
   );
@@ -244,7 +244,7 @@ it("should construct the correct query with maximumMessageId param", async () =>
         { name: "@fiscalCode", value: aRetrievedMessageWithContent.fiscalCode },
         { name: "@maxId", value: "A_MESSAGE_ID" }
       ],
-      query: "SELECT * FROM m WHERE m.fiscalCode = @fiscalCode AND m.id < @maxId ORDER BY m.id DESC"
+      query: "SELECT * FROM m WHERE m.fiscalCode = @fiscalCode AND m.id < @maxId ORDER BY m.fiscalCode, m.id DESC"
     },
     { maxItemCount: 2 }
   );
@@ -289,7 +289,7 @@ it("should construct the correct query with minimumMessageId param", async () =>
         { name: "@fiscalCode", value: aRetrievedMessageWithContent.fiscalCode },
         { name: "@minId", value: "A_MESSAGE_ID" }
       ],
-      query: "SELECT * FROM m WHERE m.fiscalCode = @fiscalCode AND m.id > @minId ORDER BY m.id DESC"
+      query: "SELECT * FROM m WHERE m.fiscalCode = @fiscalCode AND m.id > @minId ORDER BY m.fiscalCode, m.id DESC"
     },
     { maxItemCount: 2 }
   );

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -283,7 +283,7 @@ export class MessageModel extends CosmosdbModel<
           ...nextMessagesParams.param,
           ...prevMessagesParams.param
         ],
-        query: `${commonQuerySpec.query}${nextMessagesParams.condition}${prevMessagesParams.condition} ORDER BY m.id DESC`
+        query: `${commonQuerySpec.query}${nextMessagesParams.condition}${prevMessagesParams.condition} ORDER BY m.${MESSAGE_MODEL_PK_FIELD}, m.id DESC`
       })),
       TE.chain(querySpec =>
         TE.fromEither(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- fixed query to order by fiscalCode other than by id to use the new composite index
- modified container init function of integrations' tests to accept an indexing policy

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Order by id kills cosmosdb performance on huge collections. With the composite index and ordering we avoid this issue.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- yarn lint
- yarn build
- yarn test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
