### PR TITLE
[#IP-189] Add specific group for payment messages with payee

### DIFF
--- a/src/utils/middlewares/azure_api_auth.ts
+++ b/src/utils/middlewares/azure_api_auth.ts
@@ -77,7 +77,10 @@ export enum UserGroup {
   ApiDebugRead = "ApiDebugRead",
 
   // messages: send messages with EU Covid Certificate access data
-  ApiMessageWriteEUCovidCert = "ApiMessageWriteEUCovidCert"
+  ApiMessageWriteEUCovidCert = "ApiMessageWriteEUCovidCert",
+
+  // messages: send messages with payee
+  ApiMessageWriteWithPayee = "ApiMessageWriteWithPayee"
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds a new group to allow payee payload only for selected services/users
#### List of Changes
<!--- Describe your changes in detail -->
- `azure_api_auth.ts`
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is needed to avoid that every one with Message Write permission could send payment message with payee.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
