### PR TITLE
Update definitions.yaml

### DIFF
--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -321,8 +321,8 @@ EnrichedMessage:
 PublicMessage:
   x-one-of: true
   allOf:
+    - $ref: "#/EnrichedMessage"
     - $ref: "#/CreatedMessageWithoutContent" 
-    - $ref: "#/EnrichedMessage" 
 MessageResponseNotificationStatus:
   type: object
   properties:


### PR DESCRIPTION
### short description
With the current spec definition of `PublicMessage` the IO app code gen `"italia-utils": "^4.1.1"`
generate this codec

```typescript
export const PublicMessage = t.union(
  [CreatedMessageWithoutContent, EnrichedMessage],
  "PublicMessage"
);

[...]

const CreatedMessageWithoutContentR = t.interface({
  id: t.string,

  fiscal_code: FiscalCode,

  created_at: Timestamp,

  sender_service_id: ServiceId
});

// optional attributes
const CreatedMessageWithoutContentO = t.partial({
  time_to_live: TimeToLiveSeconds
});


const EnrichedMessageR = t.interface({
  id: t.string,

  fiscal_code: FiscalCode,

  created_at: Timestamp,

  sender_service_id: ServiceId,

  service_name: t.string,

  organization_name: t.string,

  message_title: t.string
});

// optional attributes
const EnrichedMessageO = t.partial({
  time_to_live: TimeToLiveSeconds
});
```

Since `CreatedMessageWithoutContent` is a type representing a subset of `EnrichedMessage` it is always able to decode also an `EnrichedMessage` item.
The issue happens when an `EnrichedMessage` is decoded as `CreatedMessageWithoutContent` by cutting all the extra fields, example:

```typescript
{
  id: '00000000000000000000000020',
  fiscal_code: 'TAMMRA80A41H501I',
  created_at: '2021-09-30T15:23:39.073Z',
  sender_service_id: 'service8',
  time_to_live: 3600,
  service_name: 'reinventate virali contenuti',
  organization_name: 'Cristofaro - Fiorillo [3]',
  message_title: '💰✅ payment message'
}
```
will be decoded
```typescript
{
  id: '00000000000000000000000020',
  fiscal_code: 'TAMMRA80A41H501I',
  created_at: 2021-09-30T15:23:39.073Z,
  sender_service_id: 'service8',
  time_to_live: 3600
}
```

test are available [here](https://github.com/pagopa/io-dev-api-server/pull/79) 