### PR TITLE
[#IP-184] Add paymentData with Payee on GetMessageModel

### DIFF
--- a/openapi/__tests__/definitions.test.ts
+++ b/openapi/__tests__/definitions.test.ts
@@ -272,7 +272,7 @@ describe("CreatedMessageWithContent definition", () => {
     expect(E.isRight(messageWithContent)).toBeTruthy();
   });
 
-  it("should decode CreatedMessageWithContent with content and payment data without payee", () => {
+  it("should NOT decode CreatedMessageWithContent with content and payment data without payee", () => {
     const aMessageWithContentWithPaymentDataWithoutPayee = {
       ...aMessageWithoutContent,
       content: {
@@ -285,7 +285,7 @@ describe("CreatedMessageWithContent definition", () => {
       aMessageWithContentWithPaymentDataWithoutPayee
     );
 
-    expect(E.isRight(messageWithContent)).toBeTruthy();
+    expect(E.isLeft(messageWithContent)).toBeTruthy();
   });
 });
 

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -264,7 +264,7 @@ CreatedMessageWithContent:
     created_at:
       $ref: "#/Timestamp"
     content:
-      $ref: "#/MessageContent"
+      $ref: "#/NewMessageContent"
     sender_service_id:
       $ref: "#/ServiceId"
   required:


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- definitions.yaml
- definitions.test.ts
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is needed for exposing the correct shape for the model exposed by `GetMessage` API. Since for a payment message we should always return payee, we have to change `CreatedMessageWithContent` definition in order to make payee required in `PaymentData`
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
