### PR TITLE
[#IC-50] Composed Cosmos Versioned Model

### DIFF
--- a/src/utils/__tests__/cosmosdb_model_composed_versioned.test.ts
+++ b/src/utils/__tests__/cosmosdb_model_composed_versioned.test.ts
@@ -159,8 +159,8 @@ describe("upsert", () => {
   });
 });
 
-describe("update", () => {
-  it("should create a new document with explicit version", async () => {
+describe("create", () => {
+  it("should create a new document with version 0", async () => {
     const expectedNextVersion = 0;
     const externalKey = aMyDocument[aModelExternalKeyId];
     const pk = aMyDocument[aModelPartitionField];
@@ -188,8 +188,8 @@ describe("update", () => {
   });
 });
 
-describe("create", () => {
-  it("should create a new document with version 0", async () => {
+describe("update", () => {
+  it("should create a new document with explicit version", async () => {
     const expectedNextVersion = aRetrievedExistingDocument.version + 1;
     const externalKey = aRetrievedExistingDocument[aModelExternalKeyId];
     const pk = aRetrievedExistingDocument[aModelPartitionField];

--- a/src/utils/__tests__/cosmosdb_model_composed_versioned.test.ts
+++ b/src/utils/__tests__/cosmosdb_model_composed_versioned.test.ts
@@ -246,3 +246,20 @@ describe("findLastVersionByModelId", () => {
   });
 });
 
+describe("typings restrictions", () => {
+  it("should NOT accept modelExternalKeyId equals to partitionKeyId", () => {
+    class MyComposedModel extends CosmosdbModelComposedVersioned<
+      MyDocument,
+      MyDocument,
+      RetrievedMyDocument,
+      typeof aModelExternalKeyId,
+      // @ts-expect-error
+      typeof aModelExternalKeyId
+    > {
+      constructor(c: Container) {
+        super(c, MyDocument, RetrievedMyDocument, aModelExternalKeyId, aModelExternalKeyId);
+      }
+    }
+  });
+});
+

--- a/src/utils/__tests__/cosmosdb_model_composed_versioned.test.ts
+++ b/src/utils/__tests__/cosmosdb_model_composed_versioned.test.ts
@@ -1,0 +1,248 @@
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { CosmosdbModelComposedVersioned, generateComposedVersionedModelId } from "../cosmosdb_model_composed_versioned";
+import * as t from "io-ts";
+import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
+import { RetrievedVersionedModel } from "../cosmosdb_model_versioned";
+import { BaseModel } from "../cosmosdb_model";
+import { Container, ErrorResponse, FeedResponse, ResourceResponse } from "@azure/cosmos";
+import * as E from "fp-ts/lib/Either";
+import * as O from "fp-ts/lib/Option";
+
+const aModelExternalKeyId = "aModelExternalKeyId" as const;
+const aModelPartitionField = "aModelPartitionField" as const;
+const aModelExternalKeyValue = "aModelExternalKeyValue";
+const aModelPartitionValue = 123;
+
+const MyDocument = t.interface({
+  [aModelExternalKeyId]: t.string,
+  [aModelPartitionField]: t.number,
+  test: t.string
+});
+type MyDocument = t.TypeOf<typeof MyDocument>;
+
+// test stub that compose a document id from the tuple (externalKey, partitionKey, version)
+const documentId = (externalKey: string, partitionKey: number, version: number): NonEmptyString =>
+  generateComposedVersionedModelId<MyDocument, typeof aModelExternalKeyId, typeof aModelPartitionField>(
+    externalKey,
+    partitionKey,
+    version as NonNegativeInteger
+  );
+
+const RetrievedMyDocument = t.intersection([
+  MyDocument,
+  RetrievedVersionedModel,
+  BaseModel
+]);
+type RetrievedMyDocument = t.TypeOf<typeof RetrievedMyDocument>;
+
+class MyComposedModel extends CosmosdbModelComposedVersioned<
+  MyDocument,
+  MyDocument,
+  RetrievedMyDocument,
+  typeof aModelExternalKeyId,
+  typeof aModelPartitionField
+> {
+  constructor(c: Container) {
+    super(c, MyDocument, RetrievedMyDocument, aModelExternalKeyId, aModelPartitionField);
+  }
+}
+
+const aMyDocument = {
+  [aModelExternalKeyId]: aModelExternalKeyValue,
+  [aModelPartitionField]: aModelPartitionValue,
+  test: "aNewMyDocument"
+};
+
+const someMetadata = {
+  _etag: "_etag",
+  _rid: "_rid",
+  _self: "_self",
+  _ts: 1
+};
+
+const aRetrievedExistingDocument: RetrievedMyDocument = {
+  ...someMetadata,
+  ...aMyDocument,
+  id: documentId(aModelExternalKeyValue, aModelPartitionValue, 1),
+  version: 1 as NonNegativeInteger
+};
+const containerMock = {
+  item: jest.fn(),
+  items: {
+    create: jest
+      .fn()
+      .mockImplementation(async doc => new ResourceResponse(doc, {}, 200, 200)),
+    query: jest.fn().mockReturnValue({
+      fetchAll: async () => new FeedResponse([], {}, false)
+    }),
+    upsert: jest.fn()
+  }
+};
+const container = (containerMock as unknown) as Container;
+
+const errorResponse: ErrorResponse = new Error();
+// eslint-disable-next-line functional/immutable-data
+errorResponse.code = 500;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("upsert", () => {
+  it.each`
+    document       | currentlyOnDb                 | expectedVersion
+    ${aMyDocument} | ${undefined}                  | ${0}
+    ${aMyDocument} | ${aRetrievedExistingDocument} | ${aRetrievedExistingDocument.version + 1}
+  `(
+    "should create a document with version $expectedVersion",
+    async ({ document, currentlyOnDb, expectedVersion }) => {
+      containerMock.items.query.mockReturnValueOnce({
+        fetchAll: async () =>
+          // if currentlyOnDb is undefined return empty array
+          new FeedResponse([currentlyOnDb].filter(Boolean), {}, false)
+      });
+
+      const model = new MyComposedModel(container);
+      const result = await model.upsert(document)();
+
+      expect(containerMock.items.create).toHaveBeenCalledWith(
+        {
+          ...document,
+          id: documentId(document[aModelExternalKeyId], document[aModelPartitionField], expectedVersion),
+          version: expectedVersion
+        },
+        { disableAutomaticIdGeneration: true }
+      );
+      expect(E.isRight(result));
+      if (E.isRight(result)) {
+        expect(result.right).toEqual({
+          ...document,
+          ...someMetadata,
+          id: documentId(document[aModelExternalKeyId], document[aModelPartitionField], expectedVersion),
+          version: expectedVersion
+        });
+      }
+    }
+  );
+
+  it("should fail on query error when retrieving last version", async () => {
+    containerMock.items.query.mockReturnValueOnce({
+      fetchAll: () => Promise.reject(errorResponse)
+    });
+    const model = new MyComposedModel(container);
+
+    const result = await model.upsert(aMyDocument)();
+    expect(E.isLeft(result));
+    if (E.isLeft(result)) {
+      expect(result.left.kind).toBe("COSMOS_ERROR_RESPONSE");
+      if (result.left.kind === "COSMOS_ERROR_RESPONSE") {
+        expect(result.left.error.code).toBe(500);
+      }
+    }
+  });
+
+  it("should fail on query error when creating next version", async () => {
+    containerMock.items.query.mockReturnValueOnce({
+      fetchAll: () => Promise.resolve(new FeedResponse([], {}, false))
+    });
+    containerMock.items.create.mockRejectedValueOnce(errorResponse);
+    const model = new MyComposedModel(container);
+
+    const result = await model.upsert(aMyDocument)();
+    expect(E.isLeft(result));
+    if (E.isLeft(result)) {
+      expect(result.left.kind).toBe("COSMOS_ERROR_RESPONSE");
+      if (result.left.kind === "COSMOS_ERROR_RESPONSE") {
+        expect(result.left.error.code).toBe(500);
+      }
+    }
+  });
+});
+
+describe("update", () => {
+  it("should create a new document with explicit version", async () => {
+    const expectedNextVersion = 0;
+    const externalKey = aMyDocument[aModelExternalKeyId];
+    const pk = aMyDocument[aModelPartitionField];
+    const model = new MyComposedModel(container);
+
+    const result = await model.create(aMyDocument)();
+
+    expect(containerMock.items.create).toHaveBeenCalledWith(
+      {
+        ...aMyDocument, // base type
+        id: documentId(externalKey, pk, expectedNextVersion),
+        version: expectedNextVersion
+      },
+      { disableAutomaticIdGeneration: true }
+    );
+    expect(E.isRight(result));
+    if (E.isRight(result)) {
+      expect(result.right).toEqual({
+        ...aMyDocument,
+        ...someMetadata,
+        id: documentId(externalKey, pk, expectedNextVersion),
+        version: expectedNextVersion
+      });
+    }
+  });
+});
+
+describe("create", () => {
+  it("should create a new document with version 0", async () => {
+    const expectedNextVersion = aRetrievedExistingDocument.version + 1;
+    const externalKey = aRetrievedExistingDocument[aModelExternalKeyId];
+    const pk = aRetrievedExistingDocument[aModelPartitionField];
+    const model = new MyComposedModel(container);
+
+    const result = await model.update(aRetrievedExistingDocument)();
+
+    expect(containerMock.items.create).toHaveBeenCalledWith(
+      {
+        ...aMyDocument, // base type
+        id: documentId(externalKey, pk, expectedNextVersion),
+        version: expectedNextVersion
+      },
+      { disableAutomaticIdGeneration: true }
+    );
+    expect(E.isRight(result));
+    if (E.isRight(result)) {
+      expect(result.right).toEqual({
+        ...aMyDocument,
+        ...someMetadata,
+        id: documentId(externalKey, pk, expectedNextVersion),
+        version: expectedNextVersion
+      });
+    }
+  });
+});
+
+describe("findLastVersionByModelId", () => {
+  it("should return none when the document is not found on partitioned model", async () => {
+    const model = new MyComposedModel(container);
+    const result = await model.findLastVersionByModelId([
+      aModelExternalKeyValue,
+      aModelPartitionValue
+    ])();
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result)) {
+      expect(O.isNone(result.right)).toBeTruthy();
+    }
+  });
+
+  it("should fail on query error", async () => {
+    containerMock.items.query.mockReturnValueOnce({
+      fetchAll: () => Promise.reject(errorResponse)
+    });
+    const model = new MyComposedModel(container);
+    const result = await model.findLastVersionByModelId([aModelExternalKeyValue, aModelPartitionValue])();
+    expect(E.isLeft(result));
+    if (E.isLeft(result)) {
+      expect(result.left.kind).toBe("COSMOS_ERROR_RESPONSE");
+      if (result.left.kind === "COSMOS_ERROR_RESPONSE") {
+        expect(result.left.error.code).toBe(500);
+      }
+    }
+  });
+});
+

--- a/src/utils/cosmosdb_model_composed_versioned.ts
+++ b/src/utils/cosmosdb_model_composed_versioned.ts
@@ -32,7 +32,7 @@ export type DocumentComposedSearchKey<
   // Quick win would be to narrow T to extend BaseModel, but that way we'd lose usage flexibility
   // Hence we omit "extends BaseModel", but we check keys to be part of "T & BaseModel"
   ReferenceIdKey extends keyof (T & BaseModel),
-  // PartitionKey and ReferenceIdKey must be two different fields.
+  // PartitionKey and ReferenceIdKey must refers two different fields.
   PartitionKey extends keyof Omit<T & BaseModel, ReferenceIdKey>
 > = readonly [(T & BaseModel)[ReferenceIdKey], (T & BaseModel)[PartitionKey]];
 
@@ -66,11 +66,18 @@ export const generateComposedVersionedModelId = <
   )}-${paddedVersion}` as NonEmptyString;
 };
 
+/**
+ * This kind of model is an extension of CosmosdbModelVersioned.
+ * It can handle versioning on all documents identified by the couple T[ReferenceKey] and T[PartitionKey].
+ * To avoid drop of performance is recommandend adopt this pattern only if the number of possible values of T[ReferenceKey] for
+ * each value of T[PartitionKey] is limited.
+ */
 export abstract class CosmosdbModelComposedVersioned<
   T,
   TN extends Readonly<T>,
   TR extends Readonly<T & RetrievedVersionedModel>,
   ReferenceIdKey extends keyof T,
+  // PartitionKey field name must be different from ReferenceIdKey field name.
   PartitionKey extends keyof Omit<T, ReferenceIdKey>
 > extends CosmosdbModelVersioned<T, TN, TR, ReferenceIdKey, PartitionKey> {
   constructor(

--- a/src/utils/cosmosdb_model_composed_versioned.ts
+++ b/src/utils/cosmosdb_model_composed_versioned.ts
@@ -1,0 +1,132 @@
+import { Container, ItemDefinition, RequestOptions } from "@azure/cosmos";
+import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { pipe } from "fp-ts/lib/function";
+import * as TE from "fp-ts/lib/TaskEither";
+import * as t from "io-ts";
+import {
+  BaseModel,
+  CosmosdbModel,
+  CosmosDecodingError,
+  CosmosErrors
+} from "./cosmosdb_model";
+import {
+  CosmosdbModelVersioned,
+  RetrievedVersionedModel,
+  VersionedModel
+} from "./cosmosdb_model_versioned";
+
+/**
+ * Model a tuple which defines the references to search for a document.
+ * A Cosmodb document must be looked-up by its Identity alongside its PartitionKey.
+ * This type model require both modelIdKey and PartitionKey and handle versioning
+ * for all the possible couples.
+ *
+ * @param T the type of the document mapped by the model
+ * @param ReferenceIdKey the literal type defining the name of the ID field for the document.
+ * @param PartitionKey the literal type defining the name of the partition key field.
+ */
+export type DocumentComposedSearchKey<
+  T,
+  // T might not include base model fields ("id"), but we know they are mandatory in cosmos documents
+  // Quick win would be to narrow T to extend BaseModel, but that way we'd lose usage flexibility
+  // Hence we omit "extends BaseModel", but we check keys to be part of "T & BaseModel"
+  ReferenceIdKey extends keyof (T & BaseModel),
+  // PartitionKey and ReferenceIdKey must be two different fields.
+  PartitionKey extends keyof Omit<T & BaseModel, ReferenceIdKey>
+> = readonly [(T & BaseModel)[ReferenceIdKey], (T & BaseModel)[PartitionKey]];
+
+/**
+ * Returns a string with a composite id that has the format:
+ * REFERENCE_ID-PARTITION_KEY-VERSION
+ *
+ * REFERENCE_ID is the external key
+ * PARTITION_KEY is the document partition key
+ * VERSION is the zero-padded version of the model version
+ *
+ * @param referenceId The external key
+ * @param partitionKey The model partitionKey
+ * @param version The version of the model
+ */
+export const generateComposedVersionedModelId = <
+  T,
+  ReferenceIdKey extends keyof T,
+  PartitionKey extends keyof Omit<T, ReferenceIdKey>
+>(
+  modelId: T[ReferenceIdKey],
+  partitionKey: T[PartitionKey],
+  version: NonNegativeInteger
+): NonEmptyString => {
+  const paddingLength = 16; // length of Number.MAX_SAFE_INTEGER == 9007199254740991
+  const paddedVersion = ("0".repeat(paddingLength) + String(version)).slice(
+    -paddingLength
+  );
+  return `${String(modelId)}-${String(
+    partitionKey
+  )}-${paddedVersion}` as NonEmptyString;
+};
+
+export abstract class CosmosdbModelComposedVersioned<
+  T,
+  TN extends Readonly<T>,
+  TR extends Readonly<T & RetrievedVersionedModel>,
+  ReferenceIdKey extends keyof T,
+  PartitionKey extends keyof Omit<T, ReferenceIdKey>
+> extends CosmosdbModelVersioned<T, TN, TR, ReferenceIdKey, PartitionKey> {
+  constructor(
+    container: Container,
+    protected readonly newVersionedItemT: t.Type<TN, ItemDefinition, unknown>,
+    protected readonly retrievedItemT: t.Type<TR, unknown, unknown>,
+    protected readonly referenceIdKey: ReferenceIdKey,
+    protected readonly partitionKey: PartitionKey
+  ) {
+    super(
+      container,
+      newVersionedItemT,
+      retrievedItemT,
+      referenceIdKey,
+      partitionKey
+    );
+  }
+
+  /**
+   * Returns the value of the partition key for the provided item
+   */
+  protected readonly getPartitionKey = (o: T): T[PartitionKey] =>
+    // eslint-disable-next-line no-invalid-this
+    o[this.partitionKey];
+
+  /**
+   * Insert a document with a specific version
+   *
+   * @param o
+   * @param version
+   * @param requestOptions
+   */
+  protected createNewVersion(
+    o: T,
+    version: NonNegativeInteger,
+    requestOptions?: RequestOptions
+  ): TE.TaskEither<CosmosErrors, TR> {
+    const modelId = this.getModelId(o);
+    const partitionKey = this.getPartitionKey(o);
+    const toSave = this.beforeSave(o);
+
+    return pipe(
+      TE.fromEither(
+        t.intersection([this.newVersionedItemT, VersionedModel]).decode({
+          ...toSave,
+          id: generateComposedVersionedModelId(modelId, partitionKey, version),
+          version
+        })
+      ),
+      TE.mapLeft(CosmosDecodingError),
+      TE.chain(document =>
+        // We need to call the create method from CosmosdbModel parent Class
+        // because the super.create calls the create method from CosmosdbModelVersioned that call again
+        // createNewVersion with a deadlock.
+        CosmosdbModel.prototype.create.call(this, document, requestOptions)
+      )
+    );
+  }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
A new model type is created `CosmosdbModelComposedVersioned`.
Refactory of `CosmosdbModelVersioned` to allow override of `createNewVersion` method.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need a new model type that handle versioning for documents with a couple externalKey-partitionKey.
This model works correctly with a limited range of externalKey for a specific partition key.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
