### PR TITLE
[#IC-89] App can decode unsupported service category

### DIFF
--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -634,8 +634,15 @@ ServicePayload:
   description: A payload used to create/update a service for a user.
   x-one-of: true
   allOf:
-   - $ref: "#/VisibleServicePayload"    
+   - $ref: "#/VisibleServicePayload"
    - $ref: "#/HiddenServicePayload"
+ExtendedServicePayload:
+  allOf:
+    - $ref: "#/ServicePayload"
+    - type: object
+      properties:
+        service_metadata:
+          $ref: "#/ServiceMetadata"
 CommonServicePayload:
   description: Common properties for a ServicePayload
   type: object
@@ -681,7 +688,9 @@ VisibleServicePayload:
         description: |-
           It indicates that service appears in the service list
       service_metadata:
-        $ref: "#/ServiceMetadata"
+        description: |-
+          That service can't handle some ServiceMetadata fields (es. category)
+        $ref: "#/CommonServiceMetadata"
     required:
       - is_visible
       - service_metadata
@@ -699,11 +708,13 @@ HiddenServicePayload:
         description: |-
           It indicates that service is hidden
       service_metadata:
-        $ref: "#/ServiceMetadata"
+        description: |-
+          That service can't handle some ServiceMetadata fields (es. category)
+        $ref: "#/CommonServiceMetadata"
 Service: 
   description: A service tied to user's subscription.
   allOf:
-  - $ref: "#/ServicePayload"
+  - $ref: "#/ExtendedServicePayload"
   - type: object
     properties:
       id:
@@ -795,6 +806,7 @@ ServiceMetadata:
   allOf:
     - $ref: "#/StandardServiceMetadata"
     - $ref: "#/SpecialServiceMetadata"
+    - $ref: "#/CommonServiceMetadata"
 SpecialServiceCategory:
   type: string
   x-extensible-enum:

--- a/src/models/__tests__/notification_event.test.ts
+++ b/src/models/__tests__/notification_event.test.ts
@@ -14,6 +14,7 @@ import { MessageSubject } from "../../../generated/definitions/MessageSubject";
 import { OrganizationFiscalCode } from "../../../generated/definitions/OrganizationFiscalCode";
 import { TimeToLiveSeconds } from "../../../generated/definitions/TimeToLiveSeconds";
 import { CreatedMessageEventSenderMetadata } from "../created_message_sender_metadata";
+import { StandardServiceCategoryEnum } from "../../../generated/definitions/StandardServiceCategory";
 
 const aMessageId = "A_MESSAGE_ID" as NonEmptyString;
 const aNotificationId = "A_NOTIFICATION_ID" as NonEmptyString;
@@ -42,6 +43,7 @@ const aSenderMetadata: CreatedMessageEventSenderMetadata = {
   organizationFiscalCode: anOrganizationFiscalCode,
   organizationName: "AgID" as NonEmptyString,
   requireSecureChannels: false,
+  serviceCategory: StandardServiceCategoryEnum.STANDARD,
   serviceName: "Test" as NonEmptyString,
   serviceUserEmail: "email@example.com" as EmailAddress
 };

--- a/src/models/__tests__/service.test.ts
+++ b/src/models/__tests__/service.test.ts
@@ -302,5 +302,4 @@ describe("Special Service metadata types", () => {
     expect(E.isRight(decodedValue2)).toBeTruthy();
 
   });
-  
 });

--- a/src/models/created_message_sender_metadata.ts
+++ b/src/models/created_message_sender_metadata.ts
@@ -2,11 +2,17 @@ import * as t from "io-ts";
 
 import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { OrganizationFiscalCode } from "../../generated/definitions/OrganizationFiscalCode";
+import { ServiceCategory } from "../../generated/definitions/ServiceCategory";
+import { withDefault } from "@pagopa/ts-commons/lib/types";
+import { StandardServiceCategoryEnum } from "../../generated/definitions/StandardServiceCategory";
 
 /**
  * Sender metadata associated to a message
  */
 export const CreatedMessageEventSenderMetadata = t.interface({
+  // withDefault is required for old messages already sent with missing serviceCategory
+  // to prevent decode errors on running orchestrators. The default value is STANDARD.
+  serviceCategory: withDefault(ServiceCategory, StandardServiceCategoryEnum.STANDARD),
   departmentName: NonEmptyString,
   organizationFiscalCode: OrganizationFiscalCode,
   organizationName: NonEmptyString,

--- a/src/models/created_message_sender_metadata.ts
+++ b/src/models/created_message_sender_metadata.ts
@@ -1,22 +1,25 @@
 import * as t from "io-ts";
 
 import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { withDefault } from "@pagopa/ts-commons/lib/types";
 import { OrganizationFiscalCode } from "../../generated/definitions/OrganizationFiscalCode";
 import { ServiceCategory } from "../../generated/definitions/ServiceCategory";
-import { withDefault } from "@pagopa/ts-commons/lib/types";
 import { StandardServiceCategoryEnum } from "../../generated/definitions/StandardServiceCategory";
 
 /**
  * Sender metadata associated to a message
  */
 export const CreatedMessageEventSenderMetadata = t.interface({
-  // withDefault is required for old messages already sent with missing serviceCategory
-  // to prevent decode errors on running orchestrators. The default value is STANDARD.
-  serviceCategory: withDefault(ServiceCategory, StandardServiceCategoryEnum.STANDARD),
   departmentName: NonEmptyString,
   organizationFiscalCode: OrganizationFiscalCode,
   organizationName: NonEmptyString,
   requireSecureChannels: t.boolean,
+  // withDefault is required for old messages already sent with missing serviceCategory
+  // to prevent decode errors on running orchestrators. The default value is STANDARD.
+  serviceCategory: withDefault(
+    ServiceCategory,
+    StandardServiceCategoryEnum.STANDARD
+  ),
   serviceName: NonEmptyString,
   serviceUserEmail: EmailString
 });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
1. `ServiceMetadata` decoder can successfully decode a `Service` with an unknown service category. The `category` will be ignored.
2. `ServicePayload` accept only `CommonServiceMetadata` without category.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. The changes to `ServiceMetadata` allow unupdated apps to decode services with unknown category. This is needed to avoid forced mobile app upgrade when a new category is introduced.
2. Only Admin user can create or modify services category. Admin will use `Service` type instead other user will use `ServicePayload` type.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

unit test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
