### PR TITLE
[#IC-66]  Add Legal Data to message model and write permission

### DIFF
--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -99,6 +99,8 @@ MessageContent:
           $ref: "#/PaymentData"
         prescription_data:
           $ref: "#/PrescriptionData"
+        legal_data:
+          $ref: '#/LegalData'
         eu_covid_cert:
           $ref: "#/EUCovidCert"
         due_date:
@@ -142,6 +144,25 @@ PrescriptionData:
       $ref: "#/PrescriberFiscalCode"
   required:
     - nre
+LegalData:
+  type: object
+  properties:
+    sender_mail_from: 
+      type: string
+      minLength: 1
+    has_attachment:
+      type: boolean
+      default: false
+    message_unique_id:
+      type: string
+      minLength: 1
+    original_message_url:
+      type: string
+      minLength: 1
+  required:
+    - sender_mail_from
+    - has_attachment
+    - message_unique_id
 EUCovidCert:
   type: object
   description: |-

--- a/src/utils/middlewares/azure_api_auth.ts
+++ b/src/utils/middlewares/azure_api_auth.ts
@@ -80,7 +80,10 @@ export enum UserGroup {
   ApiMessageWriteEUCovidCert = "ApiMessageWriteEUCovidCert",
 
   // messages: send messages with payee
-  ApiMessageWriteWithPayee = "ApiMessageWriteWithPayee"
+  ApiMessageWriteWithPayee = "ApiMessageWriteWithPayee",
+
+  // messages: send messages with legal data
+  ApiMessageWriteWithLegal = "ApiMessageWriteWithLegal"
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 

--- a/src/utils/middlewares/azure_api_auth.ts
+++ b/src/utils/middlewares/azure_api_auth.ts
@@ -83,7 +83,7 @@ export enum UserGroup {
   ApiMessageWriteWithPayee = "ApiMessageWriteWithPayee",
 
   // messages: send messages with legal data
-  ApiMessageWriteWithLegal = "ApiMessageWriteWithLegal"
+  ApiMessageWriteWithLegal = "ApiMessageWriteWithLegalData"
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Message body needs a new optional block in order to store the info required by "Messaggi a Valore Legale" project.
To allow senders to fill this block, a new permision has been added.

#### List of Changes
<!--- Describe your changes in detail -->
Add LegalData definition to openapi
Add ApiMessageWriteWithLegal permission to api auth

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We needs to store the minimum info to retrieve a MVL from a PEC-SERVER.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
