### PR TITLE
[#IC-206] Enable multi-provider for Legal Message

### DIFF
--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -162,8 +162,7 @@ LegalData:
       type: string
       minLength: 1
     pec_server_service_id:
-      type: string
-      minLength: 1
+      $ref: "#/ServiceId"
   required:
     - sender_mail_from
     - has_attachment

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -161,6 +161,9 @@ LegalData:
     original_message_url:
       type: string
       minLength: 1
+    pec_server_service_id:
+      type: string
+      minLength: 1
   required:
     - sender_mail_from
     - has_attachment


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The Legal Message could be sent to IO by different PEC-SERVER. IO must store the PEC-SERVER sender ID in order to properly manage message nerichment.

#### List of Changes
<!--- Describe your changes in detail -->
Add pec_server_service_id to message legal_data

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently we do not store any info about PEC-SERVER message sender

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
