### PR TITLE
[#IC-351]  Wrap SDK Cosmos as functional (CRUD + Patch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@azure/cosmos": "^3.11.5",
+    "@azure/cosmos": "^3.15.1",
     "@pagopa/ts-commons": "^10.0.1",
     "applicationinsights": "^1.8.10",
     "azure-storage": "^2.10.5",

--- a/src/utils/__tests__/fp_cosmosdb_model.test.ts
+++ b/src/utils/__tests__/fp_cosmosdb_model.test.ts
@@ -1,0 +1,276 @@
+import * as t from "io-ts";
+
+import * as E from "fp-ts/lib/Either";
+import * as O from "fp-ts/lib/Option";
+
+import * as M from "../fp_cosmosdb_model";
+
+import { Container, ErrorResponse, ResourceResponse } from "@azure/cosmos";
+
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+
+import { BaseModel, CosmosResource } from "../cosmosdb_model";
+import { pipe } from "fp-ts/lib/function";
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+const MyDocument = t.interface({
+  pk: t.string,
+  test: t.string
+});
+type MyDocument = t.TypeOf<typeof MyDocument>;
+
+const NewMyDocument = t.intersection([MyDocument, BaseModel]);
+type NewMyDocument = t.TypeOf<typeof NewMyDocument>;
+
+const RetrievedMyDocument = t.intersection([MyDocument, CosmosResource]);
+type RetrievedMyDocument = t.TypeOf<typeof RetrievedMyDocument>;
+
+const readMock = jest.fn();
+const containerMock = {
+  item: jest.fn(),
+  items: {
+    create: jest.fn(),
+    upsert: jest.fn()
+  }
+};
+const container = (containerMock as unknown) as Container;
+
+const myClient: M.ICosmosClient<
+  MyDocument,
+  NewMyDocument,
+  RetrievedMyDocument,
+  "id"
+> = {
+  container: container,
+  newItemT: NewMyDocument,
+  retrievedItemT: RetrievedMyDocument,
+  partitionKeyT: "id"
+};
+
+const myPartitionedClient: M.ICosmosClient<
+  MyDocument,
+  NewMyDocument,
+  RetrievedMyDocument,
+  "pk"
+> = {
+  container: container,
+  newItemT: NewMyDocument,
+  retrievedItemT: RetrievedMyDocument,
+  partitionKeyT: "pk"
+};
+
+const testId = "test-id-1" as NonEmptyString;
+const testPartition = "test-partition";
+
+const aDocument = {
+  id: testId,
+  pk: testPartition,
+  test: "test"
+};
+
+export const someMetadata = {
+  _etag: "_etag",
+  _rid: "_rid",
+  _self: "_self",
+  _ts: 1
+};
+
+const errorResponse: ErrorResponse = new Error();
+// eslint-disable-next-line functional/immutable-data
+errorResponse.code = 500;
+
+describe("create", () => {
+  it("should create a document", async () => {
+    containerMock.items.create.mockResolvedValueOnce(
+      new ResourceResponse(
+        {
+          ...aDocument,
+          ...someMetadata
+        },
+        {},
+        200,
+        200
+      )
+    );
+    const result = await pipe(aDocument, M.create(myClient))();
+    expect(containerMock.items.create).toHaveBeenCalledWith(aDocument, {
+      disableAutomaticIdGeneration: true
+    });
+    expect(E.isRight(result));
+    if (E.isRight(result)) {
+      expect(result.right).toEqual({
+        ...aDocument,
+        ...someMetadata
+      });
+    }
+  });
+
+  it("should fail on query error", async () => {
+    containerMock.items.create.mockRejectedValueOnce(errorResponse);
+
+    const result = await pipe(aDocument, M.create(myClient))();
+    expect(E.isLeft(result));
+    if (E.isLeft(result)) {
+      expect(result.left.kind).toBe("COSMOS_ERROR_RESPONSE");
+      if (result.left.kind === "COSMOS_ERROR_RESPONSE") {
+        expect(result.left.error.code).toBe(500);
+      }
+    }
+  });
+
+  it("should fail on empty response", async () => {
+    containerMock.items.create.mockResolvedValueOnce({});
+
+    const result = await pipe(aDocument, M.create(myClient))();
+    expect(E.isLeft(result));
+    if (E.isLeft(result)) {
+      expect(result.left).toEqual({ kind: "COSMOS_EMPTY_RESPONSE" });
+    }
+  });
+});
+
+describe("upsert", () => {
+  it("should create a document", async () => {
+    containerMock.items.upsert.mockResolvedValueOnce({});
+    await pipe(aDocument, M.upsert(myClient))();
+    expect(containerMock.items.upsert).toHaveBeenCalledWith(aDocument, {
+      disableAutomaticIdGeneration: true
+    });
+  });
+
+  it("should fail on query error", async () => {
+    containerMock.items.upsert.mockRejectedValueOnce(errorResponse);
+    const result = await pipe(aDocument, M.upsert(myClient))();
+    expect(E.isLeft(result));
+    if (E.isLeft(result)) {
+      expect(result.left.kind).toBe("COSMOS_ERROR_RESPONSE");
+      if (result.left.kind === "COSMOS_ERROR_RESPONSE") {
+        expect(result.left.error.code).toBe(500);
+      }
+    }
+  });
+
+  it("should fail on empty response", async () => {
+    containerMock.items.upsert.mockResolvedValueOnce({});
+    const result = await pipe(aDocument, M.upsert(myClient))();
+    expect(E.isLeft(result));
+    if (E.isLeft(result)) {
+      expect(result.left).toEqual({ kind: "COSMOS_EMPTY_RESPONSE" });
+    }
+  });
+
+  it("should return the created document as retrieved type", async () => {
+    containerMock.items.upsert.mockResolvedValueOnce(
+      new ResourceResponse(
+        {
+          ...aDocument,
+          ...someMetadata
+        },
+        {},
+        200,
+        200
+      )
+    );
+    const result = await pipe(aDocument, M.upsert(myClient))();
+    expect(E.isRight(result));
+    if (E.isRight(result)) {
+      expect(result.right).toEqual({
+        ...aDocument,
+        ...someMetadata
+      });
+    }
+  });
+});
+
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
+
+describe("find", () => {
+  it("should retrieve an existing document", async () => {
+    readMock.mockResolvedValueOnce(
+      new ResourceResponse(
+        {
+          ...aDocument,
+          ...someMetadata
+        },
+        {},
+        200,
+        200
+      )
+    );
+    containerMock.item.mockReturnValue({ read: readMock });
+
+    const result = await pipe([testId], M.find(myClient))();
+    expect(containerMock.item).toHaveBeenCalledWith(testId, testId);
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result)) {
+      expect(O.isSome(result.right)).toBeTruthy();
+      expect(O.toUndefined(result.right)).toEqual({
+        ...aDocument,
+        ...someMetadata
+      });
+    }
+  });
+
+  it("should retrieve an existing document for a model with a partition", async () => {
+    readMock.mockResolvedValueOnce(
+      new ResourceResponse(
+        {
+          ...aDocument,
+          ...someMetadata
+        },
+        {},
+        200,
+        200
+      )
+    );
+    containerMock.item.mockReturnValue({ read: readMock });
+
+    const result = await pipe(
+      [testId, testPartition],
+      M.find(myPartitionedClient)
+    )();
+    expect(containerMock.item).toHaveBeenCalledWith(testId, testPartition);
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result)) {
+      expect(O.isSome(result.right)).toBeTruthy();
+      expect(O.toUndefined(result.right)).toEqual({
+        ...aDocument,
+        ...someMetadata
+      });
+    }
+  });
+
+  it("should return an empty option if the document does not exist", async () => {
+    readMock.mockResolvedValueOnce(
+      // TODO: check whether this is what the client actually returns
+      new ResourceResponse(undefined, {}, 200, 200)
+    );
+    containerMock.item.mockReturnValue({ read: readMock });
+
+    const result = await pipe([testId], M.find(myClient))();
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result)) {
+      expect(O.isNone(result.right)).toBeTruthy();
+    }
+  });
+
+  it("should return the query error", async () => {
+    readMock.mockRejectedValueOnce(
+      // TODO: check whether this is what the client actually returns
+      errorResponse
+    );
+    containerMock.item.mockReturnValue({ read: readMock });
+
+    const result = await pipe([testId], M.find(myClient))();
+    expect(E.isLeft(result));
+    if (E.isLeft(result)) {
+      expect(result.left.kind).toBe("COSMOS_ERROR_RESPONSE");
+      if (result.left.kind === "COSMOS_ERROR_RESPONSE") {
+        expect(result.left.error.code).toBe(500);
+      }
+    }
+  });
+});

--- a/src/utils/__tests__/record.test.ts
+++ b/src/utils/__tests__/record.test.ts
@@ -1,0 +1,57 @@
+import { propertiesToArray } from "../record";
+
+describe("propertiesToArray", () => {
+  it("no object input", async () => {
+    const input = "string";
+    const properties = propertiesToArray(input);
+    expect(properties).toEqual([]);
+  });
+
+  it("flat object", async () => {
+    const input = {
+      flat1: "1",
+      flat2: "2"
+    };
+
+    const properties = propertiesToArray(input);
+    expect(properties).toEqual([
+      { key: "flat1", value: "1" },
+      { key: "flat2", value: "2" }
+    ]);
+  });
+  it("single nested object", async () => {
+    const input = {
+      flat: "flat",
+      nested: {
+        nested1: "1",
+        nested2: "2"
+      }
+    };
+
+    const properties = propertiesToArray(input);
+    expect(properties).toEqual([
+      { key: "flat", value: "flat" },
+      { key: "nested.nested1", value: "1" },
+      { key: "nested.nested2", value: "2" }
+    ]);
+  });
+
+  it("multi nested object", async () => {
+    const input = {
+      flat: "flat",
+      nested1: {
+        nested11: {
+          nested111: "1",
+          nested112: "2"
+        }
+      }
+    };
+
+    const properties = propertiesToArray(input);
+    expect(properties).toEqual([
+      { key: "flat", value: "flat" },
+      { key: "nested1.nested11.nested111", value: "1" },
+      { key: "nested1.nested11.nested112", value: "2" }
+    ]);
+  });
+});

--- a/src/utils/cosmosdb_model.ts
+++ b/src/utils/cosmosdb_model.ts
@@ -112,7 +112,7 @@ export const toCosmosErrorResponse = (
     (e instanceof Error ? e : new Error(String(e))) as ErrorResponse
   );
 
-const wrapCreate = <TN, TR>(
+export const wrapCreate = <TN, TR>(
   newItemT: t.Type<TN, ItemDefinition, unknown>,
   retrievedItemT: t.Type<TR, unknown, unknown>,
   createItem: (

--- a/src/utils/fp_cosmosdb_model.ts
+++ b/src/utils/fp_cosmosdb_model.ts
@@ -1,0 +1,225 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import * as t from "io-ts";
+import * as TE from "fp-ts/TaskEither";
+import * as E from "fp-ts/Either";
+import * as O from "fp-ts/Option";
+import {
+  Container,
+  FeedOptions,
+  ItemDefinition,
+  PatchOperationType,
+  RequestOptions,
+  SqlQuerySpec
+} from "@azure/cosmos";
+import { flow, pipe } from "fp-ts/lib/function";
+import * as RA from "fp-ts/ReadonlyArray";
+import { mapAsyncIterable } from "../utils/async";
+import {
+  BaseModel,
+  CosmosResource,
+  CosmosDocumentIdKey
+} from "../utils/cosmosdb_model";
+import {
+  CosmosErrors,
+  wrapCreate,
+  DocumentSearchKey,
+  toCosmosErrorResponse,
+  CosmosDecodingError
+} from "../utils/cosmosdb_model";
+import * as R from "../utils/record";
+import { CosmosErrorResponse } from "./cosmosdb_model";
+
+export interface ICosmosClient<
+  T,
+  TN extends Readonly<T & BaseModel>,
+  TR extends Readonly<T & CosmosResource>,
+  PartitionKey extends keyof (T & BaseModel)
+> {
+  readonly container: Container;
+  readonly newItemT: t.Type<TN, ItemDefinition, unknown>;
+  readonly retrievedItemT: t.Type<TR, unknown, unknown>;
+  readonly partitionKeyT: PartitionKey;
+}
+
+/**
+ * Creates a new document.
+ *
+ * For an explanation on how the data store gets partitioned, see
+ * https://docs.microsoft.com/en-us/azure/cosmos-db/partition-data
+ */
+export const create: <
+  T,
+  TN extends Readonly<T & BaseModel>,
+  TR extends Readonly<T & CosmosResource>,
+  PartitionKey extends keyof (T & BaseModel)
+>(
+  client: ICosmosClient<T, TN, TR, PartitionKey>,
+  options?: RequestOptions
+) => (newDocument: TN) => TE.TaskEither<CosmosErrors, TR> = (
+  client,
+  options
+) => newDocument =>
+  wrapCreate(
+    client.newItemT,
+    client.retrievedItemT,
+    client.container.items.create.bind(client.container.items)
+  )(newDocument, options);
+
+/**
+ * Creates a new document or update an existing one
+ * with the provided id.
+ *
+ */
+export const upsert: <
+  T,
+  TN extends Readonly<T & BaseModel>,
+  TR extends Readonly<T & CosmosResource>,
+  PartitionKey extends keyof (T & BaseModel)
+>(
+  client: ICosmosClient<T, TN, TR, PartitionKey>,
+  options?: RequestOptions
+) => (newDocument: TN) => TE.TaskEither<CosmosErrors, TR> = (
+  client,
+  options
+) => newDocument =>
+  wrapCreate(
+    client.newItemT,
+    client.retrievedItemT,
+    client.container.items.upsert.bind(client.container.items)
+  )(newDocument, options);
+
+export const patch: <
+  T,
+  TN extends Readonly<T & BaseModel>,
+  TR extends Readonly<T & CosmosResource>,
+  PartitionKey extends keyof (T & BaseModel)
+>(
+  client: ICosmosClient<T, TN, TR, PartitionKey>,
+  options?: RequestOptions
+) => (
+  searchKey: DocumentSearchKey<TR, CosmosDocumentIdKey, PartitionKey>,
+  partialDocument: Partial<T>
+) => TE.TaskEither<CosmosErrors, TR> = (client, options) => (
+  searchKey,
+  partialDocument
+) => {
+  // documentId must be always valued,
+  // meanwhile partitionKey might be undefined
+  const documentId = searchKey[0];
+  const partitionKey = searchKey[1] || documentId;
+  return pipe(
+    partialDocument,
+    R.toArray(),
+    RA.map(entry => ({
+      op: PatchOperationType.add,
+      path: `/${entry.key}`,
+      value: entry.value
+    })),
+    readonlyPatchOperations => readonlyPatchOperations.slice(), // copy the readonly array to a mutable one
+    patchOperations =>
+      TE.tryCatch(
+        () =>
+          client.container
+            .item(documentId, partitionKey)
+            .patch(patchOperations, options),
+        toCosmosErrorResponse
+      ),
+    TE.map(patchResponse => O.fromNullable(patchResponse.resource)),
+    TE.chain(
+      TE.fromOption(() =>
+        CosmosErrorResponse({
+          code: 404,
+          message: "message item not foud for input id",
+          name: "Not Found"
+        })
+      )
+    ),
+    TE.chainEitherKW(
+      flow(client.retrievedItemT.decode, E.mapLeft(CosmosDecodingError))
+    )
+  );
+};
+
+export const find: <
+  T,
+  TN extends Readonly<T & BaseModel>,
+  TR extends Readonly<T & CosmosResource>,
+  PartitionKey extends keyof (T & BaseModel)
+>(
+  client: ICosmosClient<T, TN, TR, PartitionKey>,
+  options?: RequestOptions
+) => (
+  searchKey: DocumentSearchKey<TR, CosmosDocumentIdKey, PartitionKey>
+) => TE.TaskEither<CosmosErrors, O.Option<TR>> = (
+  client,
+  options
+) => searchKey => {
+  // documentId must be always valued,
+  // meanwhile partitionKey might be undefined
+  const documentId = searchKey[0];
+  const partitionKey = searchKey[1] || documentId;
+  return pipe(
+    TE.tryCatch(
+      () => client.container.item(documentId, partitionKey).read(options),
+      toCosmosErrorResponse
+    ),
+    TE.map(_ => O.fromNullable(_.resource)),
+    TE.chainW(maybeDocument =>
+      O.isSome(maybeDocument)
+        ? TE.fromEither(
+            pipe(
+              client.retrievedItemT.decode(maybeDocument.value),
+              E.map(O.some),
+              E.mapLeft(CosmosDecodingError)
+            )
+          )
+        : TE.fromEither(E.right(O.none))
+    )
+  );
+};
+
+/**
+ * Get an iterator to process all documents of the collection.
+ */
+export const getCollectionIterator: <
+  T,
+  TN extends Readonly<T & BaseModel>,
+  TR extends Readonly<T & CosmosResource>,
+  PartitionKey extends keyof (T & BaseModel)
+>(
+  client: ICosmosClient<T, TN, TR, PartitionKey>,
+  options?: FeedOptions
+) => () => AsyncIterable<ReadonlyArray<t.Validation<TR>>> = (
+  client,
+  options
+) => () => {
+  const iterator = client.container.items.readAll(options).getAsyncIterator();
+  return mapAsyncIterable(iterator, feedResponse =>
+    feedResponse.resources.map(client.retrievedItemT.decode)
+  );
+};
+
+/**
+ * Get an iterator to process all documents returned by a specific query.
+ */
+export const getQueryIterator: <
+  T,
+  TN extends Readonly<T & BaseModel>,
+  TR extends Readonly<T & CosmosResource>,
+  PartitionKey extends keyof (T & BaseModel)
+>(
+  client: ICosmosClient<T, TN, TR, PartitionKey>,
+  options?: FeedOptions
+) => (
+  query: string | SqlQuerySpec
+) => AsyncIterable<ReadonlyArray<t.Validation<TR>>> = (
+  client,
+  options
+) => query => {
+  const iterator = client.container.items
+    .query(query, options)
+    .getAsyncIterator();
+  return mapAsyncIterable(iterator, feedResponse =>
+    feedResponse.resources.map(client.retrievedItemT.decode)
+  );
+};

--- a/src/utils/record.ts
+++ b/src/utils/record.ts
@@ -1,0 +1,40 @@
+import { pipe } from "fp-ts/lib/function";
+import * as RA from "fp-ts/ReadonlyArray";
+
+interface IEntry {
+  readonly key: string;
+  readonly value: unknown;
+}
+
+export const isObject = (i: unknown): i is Record<string, unknown> =>
+  typeof i === "object" &&
+  i !== null &&
+  !Object.keys(i).some(property => typeof property !== "string");
+
+export const propertiesToArray = (input: unknown): ReadonlyArray<IEntry> => {
+  const addDelimiter = (a: string, b: string): string => (a ? `${a}.${b}` : b);
+
+  const paths = (obj: unknown, head = ""): ReadonlyArray<IEntry> =>
+    isObject(obj)
+      ? pipe(
+          obj,
+          Object.entries,
+          RA.reduce(
+            [] as ReadonlyArray<IEntry>, // cast required in order to avoid never[] automatic assigned type to empty array
+            (output, [key, value]) =>
+              pipe(addDelimiter(head, key), fullPath =>
+                isObject(value)
+                  ? output.concat(paths(value, fullPath))
+                  : output.concat([{ key: fullPath, value }])
+              )
+          )
+        )
+      : [];
+
+  return paths(input);
+};
+
+export const toArray: () => (
+  input: unknown
+) => // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+ReadonlyArray<IEntry> = () => input => propertiesToArray(input);

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,16 +17,16 @@
     "@azure/abort-controller" "^1.0.0"
     tslib "^2.2.0"
 
-"@azure/core-rest-pipeline@^1.1.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@azure/core-rest-pipeline/-/core-rest-pipeline-1.2.0.tgz#c6b749f1f8fbf3f52d842b0a5cfe2d46f3e0ae06"
-  integrity sha512-oOd8feRcuoSUwflPNLPO8x6v+m4TcJ9DmazlouuG9d64zJJEwaU757ovpRss9zaL8cggUAdm84C4EbtZ/ltMAw==
+"@azure/core-rest-pipeline@^1.2.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-rest-pipeline/-/core-rest-pipeline-1.6.0.tgz#f833a0836779a40300a3633fa73ad8a63186ca73"
+  integrity sha512-9Euoat1TPR97Q1l5aylxhDyKbtp2hv15AoFeOwC5frQAFNJegtDDf6BUBr7OiAggzjGAYidxkyhL0T6Yu05XWQ==
   dependencies:
     "@azure/abort-controller" "^1.0.0"
     "@azure/core-auth" "^1.3.0"
     "@azure/core-tracing" "1.0.0-preview.13"
     "@azure/logger" "^1.0.0"
-    form-data "^3.0.0"
+    form-data "^4.0.0"
     http-proxy-agent "^4.0.1"
     https-proxy-agent "^5.0.0"
     tslib "^2.2.0"
@@ -40,17 +40,17 @@
     "@opentelemetry/api" "^1.0.1"
     tslib "^2.2.0"
 
-"@azure/cosmos@^3.11.5":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@azure/cosmos/-/cosmos-3.13.0.tgz#055364618dc202d7c1ca70bada1ed66b4e7b456c"
-  integrity sha512-w6muuUmVoJgJt3g+pRl/dd//YPq+OmJ65465egGsZ1EQc8bCPyUNs4DdWVA7xDZG5UmqP6UFw0FzVqzg5B/d7A==
+"@azure/cosmos@^3.15.1":
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/@azure/cosmos/-/cosmos-3.15.1.tgz#5b206f061cdf0bb387cf92ac13e25c9190f929c4"
+  integrity sha512-Pjn9CcoipUSsm/r9ZqAeyrqIQnh0AOeIDwYs/3pcLumK9ezCVFrfeLoOfas4Dm2X8bwL+/9puKAM55LJEaQwWg==
   dependencies:
     "@azure/core-auth" "^1.3.0"
-    "@azure/core-rest-pipeline" "^1.1.0"
+    "@azure/core-rest-pipeline" "^1.2.0"
     debug "^4.1.1"
-    fast-json-stable-stringify "^2.0.0"
+    fast-json-stable-stringify "^2.1.0"
     jsbi "^3.1.3"
-    node-abort-controller "^1.2.0"
+    node-abort-controller "^3.0.0"
     priorityqueuejs "^1.0.0"
     semaphore "^1.0.5"
     tslib "^2.2.0"
@@ -2986,7 +2986,7 @@ fast-glob@^3.1.1:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -3161,6 +3161,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -5879,10 +5888,10 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-node-abort-controller@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-1.2.1.tgz#1eddb57eb8fea734198b11b28857596dc6165708"
-  integrity sha512-79PYeJuj6S9+yOHirR0JBLFOgjB6sQCir10uN6xRx25iD+ZD4ULqgRn3MwWBRaQGB0vEgReJzWwJo42T1R6YbQ==
+node-abort-controller@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.0.1.tgz#f91fa50b1dee3f909afabb7e261b1e1d6b0cb74e"
+  integrity sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==
 
 node-cleanup@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Allow cosmos SDK to be used as functional programming (fp-ts style). Cover the CRUD and PATCH (partial update) operations for not versioned model.

#### List of Changes
<!--- Describe your changes in detail -->
Add CRUD wrapper
Add PATCH wrapper
Add propertiesToArray function to flat a nested object

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need all the object to perofmr and update (or upsert) operation on cosmos collection. With the wrapper we can modify a single collection field without knowning the entire document. The operations will be callable directly from a pipe or a flow.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
