### PR TITLE
[#IC-349] Add fiscalCode to messageStatusUpdater

### DIFF
--- a/src/models/__tests__/message_status.test.ts
+++ b/src/models/__tests__/message_status.test.ts
@@ -3,7 +3,7 @@
 import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import { NonNegativeNumber } from "@pagopa/ts-commons/lib/numbers";
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 import { Container, ResourceResponse } from "@azure/cosmos";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
@@ -17,9 +17,11 @@ import {
 import { pipe } from "fp-ts/lib/function";
 
 const aMessageId = "A_MESSAGE_ID" as NonEmptyString;
+const aFiscalCode = "RLDBSV36A78Y792X" as FiscalCode;
 
 const aSerializedMessageStatus = {
   messageId: aMessageId,
+  fiscalCode: aFiscalCode,
   status: MessageStatusValueEnum.ACCEPTED,
   updatedAt: new Date().toISOString()
 };
@@ -227,7 +229,7 @@ describe("getMessageStatusUpdater", () => {
 
     const model = new MessageStatusModel(containerMock);
 
-    const updater = getMessageStatusUpdater(model, aNewMessageId);
+    const updater = getMessageStatusUpdater(model, aNewMessageId, aFiscalCode);
 
     const res = await updater(newStatus)();
 
@@ -238,6 +240,7 @@ describe("getMessageStatusUpdater", () => {
           version: 0,
           status: newStatus,
           messageId: aNewMessageId,
+          fiscalCode: aFiscalCode,
           isRead: false,
           isArchived: false
         })
@@ -261,7 +264,7 @@ describe("getMessageStatusUpdater", () => {
 
     const model = new MessageStatusModel(containerMock);
 
-    const updater = getMessageStatusUpdater(model, aNewMessageId);
+    const updater = getMessageStatusUpdater(model, aNewMessageId, aFiscalCode);
 
     const res = await updater(newStatus)();
 
@@ -272,6 +275,7 @@ describe("getMessageStatusUpdater", () => {
           version: 1,
           status: newStatus,
           messageId: aNewMessageId,
+          fiscalCode: aFiscalCode,
           isRead: false,
           isArchived: false
         })
@@ -297,7 +301,7 @@ describe("getMessageStatusUpdater", () => {
 
     const model = new MessageStatusModel(containerMock);
 
-    const updater = getMessageStatusUpdater(model, aNewMessageId);
+    const updater = getMessageStatusUpdater(model, aNewMessageId, aFiscalCode);
 
     const res = await updater(newStatus)();
 
@@ -308,6 +312,7 @@ describe("getMessageStatusUpdater", () => {
           version: 1,
           status: newStatus,
           messageId: aNewMessageId,
+          fiscalCode: aFiscalCode,
           isRead: true,
           isArchived: true
         })

--- a/src/models/message_status.ts
+++ b/src/models/message_status.ts
@@ -1,4 +1,4 @@
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as t from "io-ts";
 
 import { Container } from "@azure/cosmos";
@@ -18,7 +18,6 @@ import {
   RetrievedVersionedModel
 } from "../utils/cosmosdb_model_versioned";
 import { wrapWithKind } from "../utils/types";
-import { FiscalCode } from "../../generated/definitions/FiscalCode";
 
 export const MESSAGE_STATUS_COLLECTION_NAME = "message-status";
 export const MESSAGE_STATUS_MODEL_ID_FIELD = "messageId" as const;
@@ -68,18 +67,18 @@ export type MessageStatusUpdater = (
  */
 export const getMessageStatusUpdater = (
   messageStatusModel: MessageStatusModel,
-  messageId: NonEmptyString
+  messageId: NonEmptyString,
+  fiscalCode: FiscalCode
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 ): MessageStatusUpdater => status =>
   pipe(
     messageStatusModel.findLastVersionByModelId([messageId]),
     TE.map(
-      O.getOrElse(() => ({
-        messageId,
-        // eslint-disable-next-line sort-keys
+      O.getOrElseW(() => ({
+        fiscalCode,
+        isArchived: false,
         isRead: false,
-        // eslint-disable-next-line sort-keys
-        isArchived: false
+        messageId
       }))
     ),
     TE.chain(item =>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The messageStatus updater is also used by io-functions-service to create the document. The updater use the upsert operations, so it will properly work also in this case. In order to properly create the document, we need to give the fiscalCode in input.

#### List of Changes
<!--- Describe your changes in detail -->
Add fiscalCode  to message_status updater 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without the fiscalCode parameter, the updater will always remove the field fiscalCode from the document.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
