### PR TITLE
[#IC-394] Wrong cosmos inner field naming on patch 

### DIFF
--- a/src/utils/__tests__/record.test.ts
+++ b/src/utils/__tests__/record.test.ts
@@ -31,8 +31,8 @@ describe("propertiesToArray2", () => {
     const properties = propertiesToArray(input);
     expect(properties).toEqual([
       { key: "flat", value: "flat" },
-      { key: "nested.nested1", value: "1" },
-      { key: "nested.nested2", value: "2" }
+      { key: "nested/nested1", value: "1" },
+      { key: "nested/nested2", value: "2" }
     ]);
   });
 
@@ -50,8 +50,8 @@ describe("propertiesToArray2", () => {
     const properties = propertiesToArray(input);
     expect(properties).toEqual([
       { key: "flat", value: "flat" },
-      { key: "nested1.nested11.nested111", value: "1" },
-      { key: "nested1.nested11.nested112", value: "2" }
+      { key: "nested1/nested11/nested111", value: "1" },
+      { key: "nested1/nested11/nested112", value: "2" }
     ]);
   });
 });

--- a/src/utils/record.ts
+++ b/src/utils/record.ts
@@ -20,7 +20,7 @@ export const isObject = (i: unknown): i is Record<string, unknown> =>
  * @returns an array of all the input object {key,value}
  */
 export const propertiesToArray = (input: unknown): ReadonlyArray<IEntry> => {
-  const addDelimiter = (a: string, b: string): string => (a ? `${a}.${b}` : b);
+  const addDelimiter = (a: string, b: string): string => (a ? `${a}/${b}` : b);
 
   const paths = (obj: unknown, head = ""): ReadonlyArray<IEntry> =>
     isObject(obj)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
When patching a cosmos nested object, the field name with . is not properly managed.
Fixed switching to _/_ delimiter.

#### List of Changes
<!--- Describe your changes in detail -->
Replaced delimiter on patch

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Proper manage nested object

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test
system test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
