### PR TITLE
[FIX]  ThirdPartyData id as NonEmptyString

### DIFF
--- a/openapi/__tests__/definitions.test.ts
+++ b/openapi/__tests__/definitions.test.ts
@@ -575,6 +575,49 @@ describe("Type definition", () => {
       )
     );
   });
+
+  it("should fail decoding a MessageContent with Third Party data without id", () => {
+    const aContentWithThirdPartyDataWithoutId = {
+      ...aContentWithoutPaymentData,
+      third_party_data: {
+        original_sender: "Comune di Mêlée"
+      }
+    };
+
+    const decodedMessageContent = MessageContent.decode(
+      aContentWithThirdPartyDataWithoutId
+    );
+
+    pipe(
+      decodedMessageContent,
+      E.fold(
+        () => expect(1).toBe(1),
+        _ => fail()
+      )
+    );
+  });
+
+  it("should fail decoding a MessageContent with Third Party data without with empty summary", () => {
+    const aContentWithThirdPartyDataWithoutSummary = {
+      ...aContentWithThirdPartyData,
+      third_party_data: {
+        ...aContentWithThirdPartyData.third_party_data,
+        summary: ""
+      }
+    };
+
+    const decodedMessageContent = MessageContent.decode(
+      aContentWithThirdPartyDataWithoutSummary
+    );
+
+    pipe(
+      decodedMessageContent,
+      E.fold(
+        () => expect(1).toBe(1),
+        _ => fail()
+      )
+    );
+  });
 });
 
 describe("ServiceMetadata", () => {

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -188,6 +188,7 @@ ThirdPartyData:
     id:
       type: string
       description: Unique id for retrieving third party enriched information about the message
+      minLength: 1
     original_sender:
         type: string
         description: |-


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->


#### List of Changes
<!--- Describe your changes in detail -->

- update ThirdPartyData definition to expect id as NonEmptyString


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

ThirdParty id must be always defined

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
