### PR TITLE
[#ICC-84] Add NotHasComponent as default for third_party component in message_view

### DIFF
--- a/src/models/__tests__/message_view.test.ts
+++ b/src/models/__tests__/message_view.test.ts
@@ -194,6 +194,14 @@ describe("message_view", () => {
       );
     }
   });
+
+  it("GIVEN a valid message_view without third party object WHEN the object is decode THEN the decode succeed", async () => {
+    const result = MessageView.decode({
+      ...aMessageView,
+      components: { ...aComponents, thirdParty: undefined }
+    });
+    expect(E.isRight(result)).toBeTruthy();
+  });
 });
 
 describe("create", () => {

--- a/src/models/__tests__/message_view.test.ts
+++ b/src/models/__tests__/message_view.test.ts
@@ -196,9 +196,11 @@ describe("message_view", () => {
   });
 
   it("GIVEN a valid message_view without third party object WHEN the object is decode THEN the decode succeed", async () => {
+    const { thirdParty, ...componentsWithoutThirdParty } = aComponents;
+
     const result = MessageView.decode({
       ...aMessageView,
-      components: { ...aComponents, thirdParty: undefined }
+      components: componentsWithoutThirdParty
     });
     expect(E.isRight(result)).toBeTruthy();
   });

--- a/src/models/message_view.ts
+++ b/src/models/message_view.ts
@@ -64,7 +64,7 @@ export const Components = t.interface({
   euCovidCert: Component,
   legalData: Component,
   payment: PaymentComponent,
-  thirdParty: ThirdPartyComponent
+  thirdParty: withDefault(ThirdPartyComponent, { has: false })
 });
 export type Components = t.TypeOf<typeof Components>;
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add a default for third_party component in the message_view decoder in order to decode legacy view documents. The default will be "NotHasComponent" becouse legacy documents could never contains a third_party data,

#### List of Changes
<!--- Describe your changes in detail -->
Add default to third_party component on message_view decoder

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This default will allow us to decode legacy view documents without re-build the entire view.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
