### PR TITLE
[#IOCIT-27] Change AppVersion definition with pattern instead x-import

### DIFF
--- a/openapi/__tests__/definitions.test.ts
+++ b/openapi/__tests__/definitions.test.ts
@@ -972,12 +972,12 @@ type IfEquals<T, U, Y = unknown, N = never> = (<G>() => G extends T
   : 2) extends <G>() => G extends U ? 1 : 2
   ? Y
   : N;
-declare const exactType: <T, U>(
+const exactType: <T, U>(
   draft: T & IfEquals<T, U>,
   expected: U & IfEquals<T, U>
-) => IfEquals<T, U>;
-declare const semver: Semver;
-declare const appVersion: AppVersion;
+) => IfEquals<T, U> = (_, __) => _;
+let semver: Semver;
+let appVersion: AppVersion;
 
 describe("Semver and AppVersion compatibility", () => {
   it("Should decode successfully a valid semver string", () => {

--- a/openapi/__tests__/definitions.test.ts
+++ b/openapi/__tests__/definitions.test.ts
@@ -33,6 +33,9 @@ import { Change_typeEnum as ReadingChangeType } from "../../generated/definition
 import { Change_typeEnum as ArchinvingChangeType } from "../../generated/definitions/MessageStatusArchivingChange";
 import { FeatureLevelTypeEnum } from "../../generated/definitions/FeatureLevelType";
 import { ThirdPartyMessage } from "../../generated/definitions/ThirdPartyMessage";
+import { Semver } from "@pagopa/ts-commons/lib/strings";
+
+import { AppVersion } from "../../generated/definitions/AppVersion";
 
 describe("ServicePayload definition", () => {
   const commonServicePayload = {
@@ -957,5 +960,38 @@ describe("ThirdPartyMessage", () => {
       E.map(d => expect(d).toEqual(aThirdPartyMessage)),
       E.mapLeft(_ => fail())
     );
+  });
+});
+
+/**
+ * Semver type and AppVersion definition compatibility tests
+ */
+
+type IfEquals<T, U, Y = unknown, N = never> = (<G>() => G extends T
+  ? 1
+  : 2) extends <G>() => G extends U ? 1 : 2
+  ? Y
+  : N;
+declare const exactType: <T, U>(
+  draft: T & IfEquals<T, U>,
+  expected: U & IfEquals<T, U>
+) => IfEquals<T, U>;
+declare const semver: Semver;
+declare const appVersion: AppVersion;
+
+describe("Semver and AppVersion compatibility", () => {
+  it("Should decode successfully a valid semver string", () => {
+    const semver = "1.10.1" as Semver;
+    const decoded = AppVersion.decode(semver);
+    expect(E.isRight(decoded)).toBeTruthy();
+  });
+  it("Should fail the decode of a invalid semver string", () => {
+    const semver = "1.10.01" as Semver;
+    const decoded = AppVersion.decode(semver);
+    expect(E.isLeft(decoded)).toBeTruthy();
+  });
+  it("Typescript type are compatible and interchangeable", () => {
+    exactType(semver, appVersion);
+    exactType(appVersion, semver);
   });
 });

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -760,9 +760,8 @@ IsTestProfile:
   default: false
 AppVersion:
   type: string
-  format: Semver
+  pattern: '^((0|[1-9]\\d*)\\.){2}(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)){0,1}$'
   description: A string field in Semantic Versioning format
-  x-import: '@pagopa/ts-commons/lib/strings'
   example: "1.10.11"
 TimeToLiveSeconds:
   type: integer


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
`last_app_version` field is a pattern string instead a `x-import` of `Semver` from `@pagopa/ts-commons`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The IO App cannot update `ts-commons` to import `Semver` for compatibility issues.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
