### PR TITLE
[#ICC-167]  Fix get message error 500 when retrieving message without content

### DIFF
--- a/src/models/__tests__/message.test.ts
+++ b/src/models/__tests__/message.test.ts
@@ -818,6 +818,32 @@ describe("getContentFromBlob", () => {
     getBlobAsTextSpy.mockReset();
   });
 
+  it("should get an error if storage return an error", async () => {
+    const err = {
+      name: "StorageError",
+      message:
+        "Generic Error. \nRequestId:27149c2d-001e-000e-2d04-a12766000000\nTime:2022-07-26T15:27:59.0934919Z",
+      code: "GenericError",
+      statusCode: 500,
+      requestId: "27149c2d-001e-000e-2d04-a12766000000"
+    };
+    const getBlobAsTextSpy = jest
+      .spyOn(azureStorageUtils, "getBlobAsTextWithError")
+      .mockReturnValueOnce(() => TE.left(err));
+
+    const errorOrMaybeMessageContent = await model.getContentFromBlob(
+      blobServiceMock as any,
+      aMessageId
+    )();
+
+    expect(E.isLeft(errorOrMaybeMessageContent)).toBeTruthy();
+    if (E.isLeft(errorOrMaybeMessageContent)) {
+      expect(errorOrMaybeMessageContent.left).toEqual(new Error(err.message));
+    }
+
+    getBlobAsTextSpy.mockReset();
+  });
+
   it("should fail with an error when the retrieved blob is empty", async () => {
     const getBlobAsTextSpy = jest
       .spyOn(azureStorageUtils, "getBlobAsTextWithError")

--- a/src/models/__tests__/message.test.ts
+++ b/src/models/__tests__/message.test.ts
@@ -2,6 +2,7 @@
 
 import * as azureStorage from "azure-storage";
 import * as E from "fp-ts/lib/Either";
+import * as TE from "fp-ts/TaskEither";
 import * as O from "fp-ts/lib/Option";
 import * as asyncI from "../../utils/async";
 
@@ -762,11 +763,12 @@ describe("getContentFromBlob", () => {
   const model = new MessageModel(containerMock, MESSAGE_CONTAINER_NAME);
 
   it("should get message content from stored blob", async () => {
+    const mockGetBlobById = jest.fn(() =>
+      TE.right(some(JSON.stringify(aMessageContent)))
+    );
     const getBlobAsTextSpy = jest
-      .spyOn(azureStorageUtils, "getBlobAsText")
-      .mockReturnValueOnce(
-        Promise.resolve(E.right(some(JSON.stringify(aMessageContent))))
-      );
+      .spyOn(azureStorageUtils, "getBlobAsTextWithError")
+      .mockReturnValueOnce(mockGetBlobById);
 
     const errorOrMaybeMessageContent = await model.getContentFromBlob(
       blobServiceMock as any,
@@ -775,9 +777,9 @@ describe("getContentFromBlob", () => {
 
     expect(getBlobAsTextSpy).toBeCalledWith(
       blobServiceMock,
-      expect.any(String), // Container name
-      `${aMessageId}.json`
+      expect.any(String) // Container name
     );
+    expect(mockGetBlobById).toBeCalledWith(`${aMessageId}.json`);
     expect(E.isRight(errorOrMaybeMessageContent)).toBeTruthy();
     if (E.isRight(errorOrMaybeMessageContent)) {
       const maybeMessageContent = errorOrMaybeMessageContent.right;
@@ -790,20 +792,27 @@ describe("getContentFromBlob", () => {
     getBlobAsTextSpy.mockReset();
   });
 
-  it("should fail with an error when the blob cannot be retrieved", async () => {
-    const err = Error();
+  it("should get a none if blob do not exists", async () => {
+    const err = {
+      name: "StorageError",
+      message:
+        "The specified blob does not exist.\nRequestId:27149c2d-001e-000e-2d04-a12766000000\nTime:2022-07-26T15:27:59.0934919Z",
+      code: "BlobNotFound",
+      statusCode: 404,
+      requestId: "27149c2d-001e-000e-2d04-a12766000000"
+    };
     const getBlobAsTextSpy = jest
-      .spyOn(azureStorageUtils, "getBlobAsText")
-      .mockReturnValueOnce(Promise.resolve(E.left(err)));
+      .spyOn(azureStorageUtils, "getBlobAsTextWithError")
+      .mockReturnValueOnce(() => TE.left(err));
 
     const errorOrMaybeMessageContent = await model.getContentFromBlob(
       blobServiceMock as any,
       aMessageId
     )();
 
-    expect(E.isLeft(errorOrMaybeMessageContent)).toBeTruthy();
-    if (E.isLeft(errorOrMaybeMessageContent)) {
-      expect(errorOrMaybeMessageContent.left).toEqual(err);
+    expect(E.isRight(errorOrMaybeMessageContent)).toBeTruthy();
+    if (E.isRight(errorOrMaybeMessageContent)) {
+      expect(errorOrMaybeMessageContent.right).toEqual(none);
     }
 
     getBlobAsTextSpy.mockReset();
@@ -811,8 +820,8 @@ describe("getContentFromBlob", () => {
 
   it("should fail with an error when the retrieved blob is empty", async () => {
     const getBlobAsTextSpy = jest
-      .spyOn(azureStorageUtils, "getBlobAsText")
-      .mockResolvedValueOnce(E.right(none));
+      .spyOn(azureStorageUtils, "getBlobAsTextWithError")
+      .mockReturnValueOnce(() => TE.right(none));
 
     const errorOrMaybeMessageContent = await model.getContentFromBlob(
       blobServiceMock as any,
@@ -830,9 +839,30 @@ describe("getContentFromBlob", () => {
   it("should fail with an error when the retrieved blob can't be decoded", async () => {
     const invalidMessageContent = {};
     const getBlobAsTextSpy = jest
-      .spyOn(azureStorageUtils, "getBlobAsText")
-      .mockResolvedValueOnce(
-        E.right(some(JSON.stringify(invalidMessageContent)))
+      .spyOn(azureStorageUtils, "getBlobAsTextWithError")
+      .mockReturnValueOnce(() =>
+        TE.right(some(JSON.stringify(invalidMessageContent)))
+      );
+
+    const errorOrMaybeMessageContent = await model.getContentFromBlob(
+      blobServiceMock as any,
+      aMessageId
+    )();
+
+    expect(E.isLeft(errorOrMaybeMessageContent)).toBeTruthy();
+    if (E.isLeft(errorOrMaybeMessageContent)) {
+      expect(errorOrMaybeMessageContent.left).toBeInstanceOf(Error);
+    }
+
+    getBlobAsTextSpy.mockReset();
+  });
+
+  it("should fail with an error when the retrieved blob can't be decoded", async () => {
+    const invalidMessageContent = {};
+    const getBlobAsTextSpy = jest
+      .spyOn(azureStorageUtils, "getBlobAsTextWithError")
+      .mockReturnValueOnce(() =>
+        TE.right(some(JSON.stringify(invalidMessageContent)))
       );
 
     const errorOrMaybeMessageContent = await model.getContentFromBlob(

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -30,7 +30,11 @@ import { FiscalCode } from "../../generated/definitions/FiscalCode";
 import { ServiceId } from "../../generated/definitions/ServiceId";
 import { Timestamp } from "../../generated/definitions/Timestamp";
 import { TimeToLiveSeconds } from "../../generated/definitions/TimeToLiveSeconds";
-import { getBlobAsText, upsertBlobFromObject } from "../utils/azure_storage";
+import {
+  getBlobAsText,
+  getBlobAsTextWithError,
+  upsertBlobFromObject
+} from "../utils/azure_storage";
 import { wrapWithKind } from "../utils/types";
 import { NewMessageContent } from "../../generated/definitions/NewMessageContent";
 import { FeatureLevelType } from "../../generated/definitions/FeatureLevelType";
@@ -397,11 +401,7 @@ export class MessageModel extends CosmosdbModel<
 
     // Retrieve blob content and deserialize
     return pipe(
-      TE.tryCatch(
-        () => getBlobAsText(blobService, this.containerName, blobId),
-        E.toError
-      ),
-      TE.chain(TE.fromEither),
+      getBlobAsTextWithError(blobService, this.containerName, blobId),
       TE.chain(maybeContentAsText =>
         TE.fromEither(
           E.fromOption(

--- a/src/utils/__tests__/azure_storage.test.ts
+++ b/src/utils/__tests__/azure_storage.test.ts
@@ -29,19 +29,6 @@ const blobServiceMock = {
 };
 
 describe("getBlobAsText", () => {
-  it("IT -> should return None on BlobNotFound error", async () => {
-    const STORAGE_CONNECTION_STRING =
-      "DefaultEndpointsProtocol=https;AccountName=iomocktest;AccountKey=qw/9pReSlzvYdfJ8n7cNsXiaq12u9WXRgiMPRtYs8BC0mShAgvCEplbK7/Avd1k/LPAzBvZd6jBOqksrEMtTrg==;EndpointSuffix=core.windows.net";
-    const blobService = createBlobService(STORAGE_CONNECTION_STRING);
-    const errorOrMaybeText = await getBlobAsTextWithError(
-      blobService,
-      "message-content",
-      "NOT_EXISTING.json"
-    )();
-
-    console.log("AAAA: " + JSON.stringify(errorOrMaybeText));
-  });
-
   it("should return None on BlobNotFound error", async () => {
     const errorOrMaybeText = await getBlobAsText(
       blobServiceMock as any,

--- a/src/utils/__tests__/azure_storage.test.ts
+++ b/src/utils/__tests__/azure_storage.test.ts
@@ -8,8 +8,11 @@ import { isNone } from "fp-ts/lib/Option";
 import {
   BlobNotFoundCode,
   getBlobAsObject,
-  getBlobAsText
+  getBlobAsText,
+  getBlobAsTextWithError
 } from "../azure_storage";
+
+import { createBlobService } from "azure-storage";
 
 const TestObject = t.interface({
   prop: t.string
@@ -26,6 +29,19 @@ const blobServiceMock = {
 };
 
 describe("getBlobAsText", () => {
+  it("IT -> should return None on BlobNotFound error", async () => {
+    const STORAGE_CONNECTION_STRING =
+      "DefaultEndpointsProtocol=https;AccountName=iomocktest;AccountKey=qw/9pReSlzvYdfJ8n7cNsXiaq12u9WXRgiMPRtYs8BC0mShAgvCEplbK7/Avd1k/LPAzBvZd6jBOqksrEMtTrg==;EndpointSuffix=core.windows.net";
+    const blobService = createBlobService(STORAGE_CONNECTION_STRING);
+    const errorOrMaybeText = await getBlobAsTextWithError(
+      blobService,
+      "message-content",
+      "NOT_EXISTING.json"
+    )();
+
+    console.log("AAAA: " + JSON.stringify(errorOrMaybeText));
+  });
+
   it("should return None on BlobNotFound error", async () => {
     const errorOrMaybeText = await getBlobAsText(
       blobServiceMock as any,

--- a/src/utils/__tests__/azure_storage.test.ts
+++ b/src/utils/__tests__/azure_storage.test.ts
@@ -2,7 +2,7 @@
 
 import * as t from "io-ts";
 
-import { isRight } from "fp-ts/lib/Either";
+import { isRight, isLeft } from "fp-ts/lib/Either";
 import { isNone } from "fp-ts/lib/Option";
 
 import {
@@ -12,7 +12,7 @@ import {
   getBlobAsTextWithError
 } from "../azure_storage";
 
-import { createBlobService } from "azure-storage";
+import { GenericCode } from "../azure_storage";
 
 const TestObject = t.interface({
   prop: t.string
@@ -40,6 +40,41 @@ describe("getBlobAsText", () => {
     if (isRight(errorOrMaybeText)) {
       const maybeText = errorOrMaybeText.right;
       expect(isNone(maybeText)).toBe(true);
+    }
+  });
+});
+
+describe("getBlobAsTextWithError", () => {
+  it("should return a left with a BlobNotFound as code on BlobNotFound error", async () => {
+    const errorOrMaybeText = await getBlobAsTextWithError(
+      blobServiceMock as any,
+      undefined as any
+    )("dummy_id")();
+
+    expect(isLeft(errorOrMaybeText)).toBeTruthy();
+    if (isLeft(errorOrMaybeText)) {
+      expect(errorOrMaybeText.left).toEqual(
+        expect.objectContaining({ code: BlobNotFoundCode })
+      );
+    }
+  });
+
+  it("should return a left with a GenericCode as code on error", async () => {
+    blobServiceMock.getBlobToText.mockImplementationOnce((_, __, ___, f) => {
+      f({
+        code: GenericCode
+      });
+    });
+    const errorOrMaybeText = await getBlobAsTextWithError(
+      blobServiceMock as any,
+      undefined as any
+    )("dummy_id")();
+
+    expect(isLeft(errorOrMaybeText)).toBeTruthy();
+    if (isLeft(errorOrMaybeText)) {
+      expect(errorOrMaybeText.left).toEqual(
+        expect.objectContaining({ code: GenericCode })
+      );
     }
   });
 });

--- a/src/utils/azure_storage.ts
+++ b/src/utils/azure_storage.ts
@@ -6,6 +6,7 @@ import * as t from "io-ts";
 
 import { Either } from "fp-ts/lib/Either";
 import * as E from "fp-ts/lib/Either";
+import * as TE from "fp-ts/TaskEither";
 
 import { fromNullable, isNone, none, Option, some } from "fp-ts/lib/Option";
 
@@ -172,6 +173,7 @@ export const getBlobAsText = (
         if (err) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const errorAsStorageError = err as StorageError;
+          console.log("BBBB: " + JSON.stringify(errorAsStorageError));
           if (
             errorAsStorageError.code !== undefined &&
             errorAsStorageError.code === BlobNotFoundCode
@@ -183,6 +185,30 @@ export const getBlobAsText = (
           return resolve(E.right<Error, Option<string>>(fromNullable(result)));
         }
       }
+    );
+  });
+
+/**
+ * Get a blob content as text (string). In case of error, it will return error details
+ *
+ * @param blobService     the Azure blob service
+ * @param containerName   the name of the Azure blob storage container
+ * @param blobName        blob file name
+ */
+export const getBlobAsTextWithError = (
+  blobService: azureStorage.BlobService,
+  containerName: string,
+  blobName: string,
+  options: azureStorage.BlobService.GetBlobRequestOptions = {}
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+): TE.TaskEither<azureStorage.StorageError, Option<string>> => () =>
+  new Promise(resolve => {
+    blobService.getBlobToText(
+      containerName,
+      blobName,
+      options,
+      (err, result, _) =>
+        err ? resolve(E.left(err)) : resolve(E.right(fromNullable(result)))
     );
   });
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The getContentFromBlob method of Message model do not set apart empty blob from not existing blob. A not exisitng blob should not throw and error, becouse a message without content is valid.

#### List of Changes
<!--- Describe your changes in detail -->
add new getBlobAsTextWithError to azure utils
change getContentFromBlob method to manage 404 get blob error

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The message model is used to retrieve a message. A Service poll this method via fn-service API to known the status message as part of send message process. This polling must return a message without content if the message is not rejected/refused, but not yet processed.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
