### PR TITLE
[ICC-168] making AzureAllowBodyPayloadMiddleware error responses more…

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@azure/cosmos": "^3.15.1",
-    "@pagopa/ts-commons": "^10.5.0",
+    "@pagopa/ts-commons": "^10.9.0",
     "applicationinsights": "^1.8.10",
     "azure-storage": "^2.10.5",
     "cidr-matcher": "^2.1.1",

--- a/src/utils/middlewares/__tests__/azure_api_auth.test.ts
+++ b/src/utils/middlewares/__tests__/azure_api_auth.test.ts
@@ -360,7 +360,10 @@ describe("AzureAllowBodyPayloadMiddleware", () => {
     pipe(
       result,
       E.fold(
-        _ => expect(_.kind).toBe("IResponseErrorForbiddenNotAuthorized"),
+        _ => {
+          expect(_.kind).toBe("IResponseErrorForbiddenNotAuthorized")
+          expect(_.detail).toContain("User has no valid scopes: You are not part of any valid scope, you should ask the administrator to give you the required permissions.")
+        },
         _ => fail("Expecting left")
       )
     );
@@ -391,10 +394,83 @@ describe("AzureAllowBodyPayloadMiddleware", () => {
     pipe(
       result,
       E.fold(
-        _ =>
-          expect(_.kind).toBe("IResponseErrorForbiddenNoAuthorizationGroups"),
+        _ => {
+          expect(_.kind).toBe("IResponseErrorForbiddenNoAuthorizationGroups")
+          expect(_.detail).toContain("User has no valid scopes: You are not part of any valid scope, you should ask the administrator to give you the required permissions.")
+        },
         _ => fail("Expecting left")
       )
     );
   });
+
+  it("should return a ResponseErrorForbiddenNoAuthorizationGroups with a custom detail", async () => {
+    const headers = {
+      ...someHeaders,
+      "x-user-groups": ""
+    };
+    const aPayload = { foo: { bar: "baz" } };
+    const mockRequest = {
+      header: jest.fn(lookup(headers)),
+      body: aPayload
+    };
+    const aMatchingCodec = t.interface({
+      foo: t.interface({ bar: t.string })
+    });
+
+    const middleware = AzureAllowBodyPayloadMiddleware(
+      aMatchingCodec,
+      anAllowedGroupSet,
+      "a custom detail"
+    );
+
+    const result = await middleware(mockRequest as any);
+
+    expect(E.isLeft(result)).toBe(true);
+    pipe(
+      result,
+      E.fold(
+        _ =>{
+          expect(_.kind).toBe("IResponseErrorForbiddenNoAuthorizationGroups");
+          expect(_.detail).toContain("a custom detail");
+        },
+        _ => fail("Expecting left")
+      )
+    );
+  });
+
+  it("should return a IResponseErrorForbiddenNotAuthorized with a custom detail", async () => {
+    const headers = {
+      ...someHeaders
+    };
+    const aPayload = { foo: { bar: "baz" } };
+    const mockRequest = {
+      header: jest.fn(lookup(headers)),
+      body: aPayload
+    };
+    const aMatchingCodec = t.interface({
+      foo: t.interface({ bar: t.string })
+    });
+    const anotherAllowedGroupSet = new Set([UserGroup.ApiDebugRead]);
+
+    const middleware = AzureAllowBodyPayloadMiddleware(
+      aMatchingCodec,
+      anotherAllowedGroupSet,
+      "a custom detail"
+    );
+
+    const result = await middleware(mockRequest as any);
+
+    expect(E.isLeft(result)).toBe(true);
+    pipe(
+      result,
+      E.fold(
+        _ => {
+          expect(_.kind).toBe("IResponseErrorForbiddenNotAuthorized");
+          expect(_.detail).toContain("a custom detail");
+        },
+        _ => fail("Expecting left")
+      )
+    );
+  });
+
 });

--- a/src/utils/middlewares/__tests__/azure_api_auth.test.ts
+++ b/src/utils/middlewares/__tests__/azure_api_auth.test.ts
@@ -362,7 +362,7 @@ describe("AzureAllowBodyPayloadMiddleware", () => {
       E.fold(
         _ => {
           expect(_.kind).toBe("IResponseErrorForbiddenNotAuthorized")
-          expect(_.detail).toContain("User has no valid scopes: You are not part of any valid scope, you should ask the administrator to give you the required permissions.")
+          expect(_.detail).toContain("You are not allowed here: No valid scopes, you are not allowed to send such payloads. Ask the administrator to give you the required permissions.")
         },
         _ => fail("Expecting left")
       )
@@ -396,7 +396,7 @@ describe("AzureAllowBodyPayloadMiddleware", () => {
       E.fold(
         _ => {
           expect(_.kind).toBe("IResponseErrorForbiddenNoAuthorizationGroups")
-          expect(_.detail).toContain("User has no valid scopes: You are not part of any valid scope, you should ask the administrator to give you the required permissions.")
+          expect(_.detail).toContain("User has no valid scopes: No valid scopes, you are not allowed to send such payloads. Ask the administrator to give you the required permissions.")
         },
         _ => fail("Expecting left")
       )

--- a/src/utils/middlewares/azure_api_auth.ts
+++ b/src/utils/middlewares/azure_api_auth.ts
@@ -272,7 +272,7 @@ type AzureAllowBodyPayloadMiddlewareErrorResponses =
 export const AzureAllowBodyPayloadMiddleware = <S, A>(
   pattern: t.Type<A, S>,
   allowedGroups: ReadonlySet<UserGroup>,
-  notAllowedMessage = "User has no valid scopes: You are not part of any valid scope, you should ask the administrator to give you the required permissions."
+  notAllowedMessage = "No valid scopes, you are not allowed to send such payloads. Ask the administrator to give you the required permissions."
 ): IRequestMiddleware<
   | "IResponseErrorForbiddenNotAuthorized"
   | "IResponseErrorForbiddenNoAuthorizationGroups",
@@ -295,21 +295,18 @@ export const AzureAllowBodyPayloadMiddleware = <S, A>(
                 getResponseErrorForbiddenNoAuthorizationGroups(
                   notAllowedMessage
                 )
-              ), // User has no valid scopes: You are not part of any valid scope, you should ask the administrator to give you the required permissions.
+              ),
               E.map(getGroupsFromHeader),
               // check if current user belongs to at least one of the allowed groups
               E.map(userGroups =>
                 Array.from(allowedGroups).some(e => userGroups.has(e))
               ),
-              E.chainW(
-                isInGroup =>
-                  isInGroup
-                    ? E.right(void 0)
-                    : E.left(
-                        getResponseErrorForbiddenNotAuthorized(
-                          notAllowedMessage
-                        )
-                      ) // You are not allowed here: You do not have enough permission to complete the operation you requested
+              E.chainW(isInGroup =>
+                isInGroup
+                  ? E.right(void 0)
+                  : E.left(
+                      getResponseErrorForbiddenNotAuthorized(notAllowedMessage)
+                    )
               )
             )
         )

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,10 +703,24 @@
     write-yaml-file "^4.1.3"
     yargs "^15.0.1"
 
-"@pagopa/ts-commons@^10.3.0", "@pagopa/ts-commons@^10.5.0":
+"@pagopa/ts-commons@^10.3.0":
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/@pagopa/ts-commons/-/ts-commons-10.5.0.tgz#5c22cf3bc16af087beac5b0dfb3eef8f9231ab80"
   integrity sha512-gD0X6inD0knEU4IJtHGqJ622AIAq11pdstrFDpt87tHLRsTpOk9EJ/4yhrokGPhfInKbOEkIV1TydUZIqEQ6Vw==
+  dependencies:
+    abort-controller "^3.0.0"
+    agentkeepalive "^4.1.4"
+    applicationinsights "^1.8.10"
+    fp-ts "^2.11.0"
+    io-ts "^2.2.16"
+    json-set-map "^1.1.2"
+    node-fetch "^2.6.0"
+    validator "^13.7.0"
+
+"@pagopa/ts-commons@^10.9.0":
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/ts-commons/-/ts-commons-10.9.0.tgz#ca50f8f9b09499667b6f3532c897453918ed7c76"
+  integrity sha512-hnWpA8Le8ylxKGGj+IALFBhOQDgLDl8vb3opKr3MHVdkcvm4GONZkotGnnSQ3Bh/tasgmPbeOa4wAHJSLTRmXQ==
   dependencies:
     abort-controller "^3.0.0"
     agentkeepalive "^4.1.4"


### PR DESCRIPTION
… detailed

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
* Updated `ts-commons` to `10.9.0`
* Modified `AzureAllowBodyPayloadMiddleware` in order to use
  - `getResponseErrorForbiddenNoAuthorizationGroups`
  -  `getResponseErrorForbiddenNotAuthorized`
from the new version of `ts-commons`
* Added some unit test for the middleware

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In order to get the possibility to  specify a custom message in case of some errors i have added an optional parameter with a default.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
