### PR TITLE
[ICC-195] Add rejection_detail to MessageStatus

### DIFF
--- a/openapi/__tests__/definitions.test.ts
+++ b/openapi/__tests__/definitions.test.ts
@@ -23,7 +23,7 @@ import { CommonServiceMetadata as ApiCommonServiceMetadata } from "../../generat
 import { StandardServiceMetadata as ApiStandardServiceMetadata } from "../../generated/definitions/StandardServiceMetadata";
 import { ServiceScopeEnum } from "../../generated/definitions/ServiceScope";
 import { SpecialServiceCategoryEnum } from "../../generated/definitions/SpecialServiceCategory";
-import { MessageStatusValueEnum } from "../../generated/definitions/MessageStatusValue";
+import { NotRejectedMessageStatusValueEnum as MessageStatusValueEnum } from "../../generated/definitions/NotRejectedMessageStatusValue";
 import { MessageStatus } from "../../generated/definitions/MessageStatus";
 import { MessageStatusChange } from "../../generated/definitions/MessageStatusChange";
 import { MessageStatusAttributes } from "../../generated/definitions/MessageStatusAttributes";

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -283,8 +283,28 @@ MaxAllowedPaymentAmount:
   minimum: 0
   maximum: 9999999999
   default: 0
-MessageStatusValue:
+RejectedMessageStatusValue:
   type: string
+  x-extensible-enum:
+    - REJECTED
+RejectionReason:
+  type: string
+  x-extensible-enum:
+    - SERVICE_NOT_ALLOWED
+    - USER_NOT_FOUND
+    - UNKNOWN
+NotRejectedMessageStatusValue:
+  type: string
+  x-extensible-enum:
+    - ACCEPTED
+    - THROTTLED
+    - FAILED
+    - PROCESSED
+MessageStatusValue:
+  x-one-of: true
+  allOf:
+    - $ref: "#/RejectedMessageStatusValue"
+    - $ref: "#/NotRejectedMessageStatusValue"
   description: |-
     The processing status of a message.
     "ACCEPTED": the message has been accepted and will be processed for delivery;
@@ -295,13 +315,6 @@ MessageStatusValue:
     "PROCESSED": the message was succesfully processed and is now stored in the user's inbox;
       we'll try to send a notification for each of the selected channels
     "REJECTED": either the recipient does not exist, or the sender has been blocked
-  x-extensible-enum:
-    - ACCEPTED
-    - THROTTLED
-    - FAILED
-    - PROCESSED
-    - REJECTED
-  example: ACCEPTED
 MessageStatus:
   type: object
   properties:

--- a/src/models/__tests__/message_view.test.ts
+++ b/src/models/__tests__/message_view.test.ts
@@ -9,7 +9,7 @@ import {
   Status
 } from "../message_view";
 import { ServiceId } from "../../../generated/definitions/ServiceId";
-import { MessageStatusValueEnum } from "../../../generated/definitions/MessageStatusValue";
+import { NotRejectedMessageStatusValueEnum as MessageStatusValueEnum } from "../../../generated/definitions/NotRejectedMessageStatusValue";
 import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
 import { MessageViewModel } from "../message_view";
 import { pipe } from "fp-ts/lib/function";

--- a/src/models/message_status.ts
+++ b/src/models/message_status.ts
@@ -31,6 +31,7 @@ export const MESSAGE_STATUS_COLLECTION_NAME = "message-status";
 export const MESSAGE_STATUS_MODEL_ID_FIELD = "messageId" as const;
 export const MESSAGE_STATUS_MODEL_PK_FIELD = "messageId" as const;
 
+type CommonMessageStatus = t.TypeOf<typeof CommonMessageStatus>;
 export const CommonMessageStatus = t.intersection([
   t.interface({
     messageId: NonEmptyString,
@@ -46,6 +47,7 @@ export const CommonMessageStatus = t.intersection([
   })
 ]);
 
+type RejectedMessageStatus = t.TypeOf<typeof RejectedMessageStatus>;
 const RejectedMessageStatus = t.intersection([
   CommonMessageStatus,
   t.interface({
@@ -56,6 +58,7 @@ const RejectedMessageStatus = t.intersection([
   })
 ]);
 
+type NotRejectedMessageStatus = t.TypeOf<typeof NotRejectedMessageStatus>;
 const NotRejectedMessageStatus = t.intersection([
   CommonMessageStatus,
   t.interface({
@@ -90,17 +93,17 @@ export type RetrievedMessageStatus = t.TypeOf<typeof RetrievedMessageStatus>;
 // MessageStatusUpdater
 // --------------------------------------
 
+export type MessageStatusUpdate =
+  | {
+      readonly status: NotRejectedMessageStatusValueEnum;
+    }
+  | {
+      readonly status: RejectedMessageStatusValueEnum;
+      readonly rejection_reason: RejectedMessageStatus["rejection_reason"];
+    };
+
 export type MessageStatusUpdater = (
-  statusUpdate:
-    | {
-        readonly status: NotRejectedMessageStatusValueEnum;
-      }
-    | {
-        readonly rejection_reason: t.TypeOf<
-          typeof RejectedMessageStatus
-        >["rejection_reason"];
-        readonly status: RejectedMessageStatusValueEnum;
-      }
+  statusUpdate: MessageStatusUpdate
 ) => TE.TaskEither<CosmosErrors, RetrievedMessageStatus>;
 
 /**


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

Add `rejection_detail` to `MessageStatus`when status is `REJECTED`. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

RFC 9012- We need to distinguish the reason of a rejected message. A message can be rejected because recipient is not a user of IO, or because the service is not allowed to contact that user.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
