### PR TITLE
[#IOCIT-112] Added properties for reminder opt in

### DIFF
--- a/__integrations__/models/profile.test.ts
+++ b/__integrations__/models/profile.test.ts
@@ -447,12 +447,12 @@ describe("Models |> Profile", () => {
   );
 
   it.each`
-    inputValue   | expectedValue
-    ${undefined} | ${false}
-    ${true}      | ${true}
-    ${false}     | ${false}
+    inputValue    | expectedValue
+    ${undefined}  | ${"UNSET"}
+    ${"ENABLED"}  | ${"ENABLED"}
+    ${"DISABLED"} | ${"DISABLED"}
   `(
-    "should save records when passing consistent isReminderEnabled = $inputValue",
+    "should save records when passing consistent reminderStatus = $inputValue",
     async ({ inputValue, expectedValue }) => {
       const context = createContext(PROFILE_MODEL_PK_FIELD);
       await context.init();
@@ -461,18 +461,16 @@ describe("Models |> Profile", () => {
       const toBeSavedProfile: NewProfile = {
         kind: "INewProfile" as const,
         ...aProfile,
-        isReminderEnabled: inputValue
+        reminderStatus: inputValue
       };
 
       await pipe(
         model.create(toBeSavedProfile),
         te.bimap(
           _ =>
-            fail(
-              `Should not have failed with isReminderEnabled = ${inputValue}`
-            ),
+            fail(`Should not have failed with reminderStatus = ${inputValue}`),
           _ => {
-            expect(_.isReminderEnabled).toBe(expectedValue);
+            expect(_.reminderStatus).toBe(expectedValue);
           }
         )
       )();

--- a/__integrations__/models/profile.test.ts
+++ b/__integrations__/models/profile.test.ts
@@ -449,7 +449,6 @@ describe("Models |> Profile", () => {
   it.each`
     inputValue   | expectedValue
     ${undefined} | ${false}
-    ${null}      | ${false}
     ${true}      | ${true}
     ${false}     | ${false}
   `(

--- a/__integrations__/models/profile.test.ts
+++ b/__integrations__/models/profile.test.ts
@@ -445,4 +445,40 @@ describe("Models |> Profile", () => {
       context.dispose();
     }
   );
+
+  it.each`
+    inputValue   | expectedValue
+    ${undefined} | ${false}
+    ${null}      | ${false}
+    ${true}      | ${true}
+    ${false}     | ${false}
+  `(
+    "should save records when passing consistent isReminderEnabled = $inputValue",
+    async ({ inputValue, expectedValue }) => {
+      const context = createContext(PROFILE_MODEL_PK_FIELD);
+      await context.init();
+      const model = new ProfileModel(context.container);
+
+      const toBeSavedProfile: NewProfile = {
+        kind: "INewProfile" as const,
+        ...aProfile,
+        isReminderEnabled: inputValue
+      };
+
+      await pipe(
+        model.create(toBeSavedProfile),
+        te.bimap(
+          _ =>
+            fail(
+              `Should not have failed with isReminderEnabled = ${inputValue}`
+            ),
+          _ => {
+            expect(_.isReminderEnabled).toBe(expectedValue);
+          }
+        )
+      )();
+
+      context.dispose();
+    }
+  );
 });

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -689,8 +689,8 @@ Profile:
       $ref: "#/IsWebhookEnabled"
     is_email_enabled:
       $ref: "#/IsEmailEnabled"
-    is_reminder_enabled:
-      $ref: "#/IsReminderEnabled"
+    reminder_status:
+      $ref: "#/ReminderStatus"
     last_app_version:
       $ref: "#/AppVersion"
     version:
@@ -736,8 +736,8 @@ ExtendedProfile:
       $ref: "#/IsEmailEnabled"
     is_email_validated:
       $ref: "#/IsEmailValidated"
-    is_reminder_enabled:
-      $ref: "#/IsReminderEnabled"
+    reminder_status:
+      $ref: "#/ReminderStatus"
     is_test_profile:
       $ref: "#/IsTestProfile"
     last_app_version:
@@ -771,11 +771,16 @@ IsWebhookEnabled:
 IsEmailEnabled:
   type: boolean
   description: True if the recipient of a message wants to forward the notifications to his email address.
-IsReminderEnabled:
-  type: boolean
-  default: false
-  description: |-
-    True if the user wants reminders about unread messages.
+ReminderStatus:
+  type: string
+  x-extensible-enum:
+    - UNSET
+    - ENABLED
+    - DISABLED
+  default: UNSET
+  example: ENABLED
+  description:
+    Api definition of reminder opt-in status
 IsTestProfile:
   type: boolean
   description: True if the user's profile is only for test purpose. 

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -689,6 +689,8 @@ Profile:
       $ref: "#/IsWebhookEnabled"
     is_email_enabled:
       $ref: "#/IsEmailEnabled"
+    is_reminder_enabled:
+      $ref: "#/IsReminderEnabled"
     last_app_version:
       $ref: "#/AppVersion"
     version:
@@ -734,6 +736,8 @@ ExtendedProfile:
       $ref: "#/IsEmailEnabled"
     is_email_validated:
       $ref: "#/IsEmailValidated"
+    is_reminder_enabled:
+      $ref: "#/IsReminderEnabled"
     is_test_profile:
       $ref: "#/IsTestProfile"
     last_app_version:
@@ -767,6 +771,11 @@ IsWebhookEnabled:
 IsEmailEnabled:
   type: boolean
   description: True if the recipient of a message wants to forward the notifications to his email address.
+IsReminderEnabled:
+  type: boolean
+  default: false
+  description: |-
+    True if the user wants reminders about not read messages.
 IsTestProfile:
   type: boolean
   description: True if the user's profile is only for test purpose. 

--- a/src/models/__tests__/profile.test.ts
+++ b/src/models/__tests__/profile.test.ts
@@ -49,12 +49,15 @@ const aLastAppVersion = "1.0.0";
 
 describe("findLastVersionByModelId", () => {
   it.each`
-    case                                         | lastAppVersion     | expectedLastAppVersion | reminderStatus | expectedReminderStatus
-    ${"existing profile"}                        | ${undefined}       | ${"UNKNOWN"}           | ${undefined}      | ${"UNSET"}
-    ${"existing profile with last app version"}  | ${aLastAppVersion} | ${aLastAppVersion}     | ${undefined}      | ${"UNSET"}
-    ${"existing profile with reminder enabled"}  | ${undefined}       | ${"UNKNOWN"}           | ${"ENABLED"}      | ${"ENABLED"}
-    ${"existing profile with reminder disabled"} | ${undefined}       | ${"UNKNOWN"}           | ${"DISABLED"}     | ${"DISABLED"}
-    ${"existing profile with all props"}         | ${aLastAppVersion} | ${aLastAppVersion}     | ${"ENABLED"}      | ${"ENABLED"}
+    case                                                           | lastAppVersion     | expectedLastAppVersion | reminderStatus | expectedReminderStatus
+    ${"existing profile with no props"}                            | ${undefined}       | ${"UNKNOWN"}           | ${undefined}   | ${"UNSET"}
+    ${"existing profile with no props and unset reminder"}         | ${undefined}       | ${"UNKNOWN"}           | ${"UNSET"}     | ${"UNSET"}
+    ${"existing profile with reminder enabled"}                    | ${undefined}       | ${"UNKNOWN"}           | ${"ENABLED"}   | ${"ENABLED"}
+    ${"existing profile with reminder disabled"}                   | ${undefined}       | ${"UNKNOWN"}           | ${"DISABLED"}  | ${"DISABLED"}
+    ${"existing profile with last app version"}                    | ${aLastAppVersion} | ${aLastAppVersion}     | ${undefined}   | ${"UNSET"}
+    ${"existing profile with last app version and unset reminder"} | ${aLastAppVersion} | ${aLastAppVersion}     | ${"UNSET"}     | ${"UNSET"}
+    ${"existing profile with all props with reminder enabled"}     | ${aLastAppVersion} | ${aLastAppVersion}     | ${"ENABLED"}   | ${"ENABLED"}
+    ${"existing profile with all props with reminder disabled"}    | ${aLastAppVersion} | ${aLastAppVersion}     | ${"DISABLED"}  | ${"DISABLED"}
   `(
     "should resolve to an $case",
     async ({

--- a/src/models/__tests__/profile.test.ts
+++ b/src/models/__tests__/profile.test.ts
@@ -45,11 +45,6 @@ const aRetrievedProfile: RetrievedProfile = {
   ...aStoredProfile
 };
 
-const aRetrievedProfileWithEnabledReminder: RetrievedProfile = {
-  ...aRetrievedProfile,
-  isReminderEnabled: true
-};
-
 const aLastAppVersion = "1.0.0";
 
 describe("findLastVersionByModelId", () => {

--- a/src/models/__tests__/profile.test.ts
+++ b/src/models/__tests__/profile.test.ts
@@ -50,21 +50,38 @@ const aRetrievedProfileWithEnabledReminder: RetrievedProfile = {
   isReminderEnabled: true
 };
 
+const aLastAppVersion = "1.0.0";
+
 describe("findLastVersionByModelId", () => {
   it.each`
-    case                                        | retrievedProfile                        | expectedIsReminderEnabled
-    ${"existing profile"}                       | ${aRetrievedProfile}                    | ${false}
-    ${"existing profile with reminder enabled"} | ${aRetrievedProfileWithEnabledReminder} | ${true}
+    case                                         | lastAppVersion     | expectedLastAppVersion | isReminderEnabled | expectedIsReminderEnabled
+    ${"existing profile"}                        | ${undefined}       | ${"UNKNOWN"}           | ${undefined}      | ${false}
+    ${"existing profile with last app version"}  | ${aLastAppVersion} | ${aLastAppVersion}     | ${undefined}      | ${false}
+    ${"existing profile with reminder enabled"}  | ${undefined}       | ${"UNKNOWN"}           | ${true}           | ${true}
+    ${"existing profile with reminder disabled"} | ${undefined}       | ${"UNKNOWN"}           | ${false}          | ${false}
+    ${"existing profile with all props"}         | ${aLastAppVersion} | ${aLastAppVersion}     | ${true}           | ${true}
   `(
     "should resolve to an $case",
-    async ({ _, retrievedProfile, expectedIsReminderEnabled }) => {
+    async ({
+      _,
+      lastAppVersion,
+      expectedLastAppVersion,
+      isReminderEnabled,
+      expectedIsReminderEnabled
+    }) => {
       const containerMock = ({
         items: {
           create: jest.fn(),
           query: jest.fn(() => ({
             fetchAll: jest.fn(() =>
               Promise.resolve({
-                resources: [retrievedProfile]
+                resources: [
+                  {
+                    ...aRetrievedProfile,
+                    lastAppVersion,
+                    isReminderEnabled
+                  }
+                ]
               })
             )
           }))
@@ -87,7 +104,7 @@ describe("findLastVersionByModelId", () => {
             version: PROFILE_SERVICE_PREFERENCES_SETTINGS_LEGACY_VERSION
           },
           // we make sure that last optional properties added are with default values
-          lastAppVersion: "UNKNOWN",
+          lastAppVersion: expectedLastAppVersion,
           isReminderEnabled: expectedIsReminderEnabled
         });
       }

--- a/src/models/__tests__/profile.test.ts
+++ b/src/models/__tests__/profile.test.ts
@@ -49,20 +49,20 @@ const aLastAppVersion = "1.0.0";
 
 describe("findLastVersionByModelId", () => {
   it.each`
-    case                                         | lastAppVersion     | expectedLastAppVersion | isReminderEnabled | expectedIsReminderEnabled
-    ${"existing profile"}                        | ${undefined}       | ${"UNKNOWN"}           | ${undefined}      | ${false}
-    ${"existing profile with last app version"}  | ${aLastAppVersion} | ${aLastAppVersion}     | ${undefined}      | ${false}
-    ${"existing profile with reminder enabled"}  | ${undefined}       | ${"UNKNOWN"}           | ${true}           | ${true}
-    ${"existing profile with reminder disabled"} | ${undefined}       | ${"UNKNOWN"}           | ${false}          | ${false}
-    ${"existing profile with all props"}         | ${aLastAppVersion} | ${aLastAppVersion}     | ${true}           | ${true}
+    case                                         | lastAppVersion     | expectedLastAppVersion | reminderStatus | expectedReminderStatus
+    ${"existing profile"}                        | ${undefined}       | ${"UNKNOWN"}           | ${undefined}      | ${"UNSET"}
+    ${"existing profile with last app version"}  | ${aLastAppVersion} | ${aLastAppVersion}     | ${undefined}      | ${"UNSET"}
+    ${"existing profile with reminder enabled"}  | ${undefined}       | ${"UNKNOWN"}           | ${"ENABLED"}      | ${"ENABLED"}
+    ${"existing profile with reminder disabled"} | ${undefined}       | ${"UNKNOWN"}           | ${"DISABLED"}     | ${"DISABLED"}
+    ${"existing profile with all props"}         | ${aLastAppVersion} | ${aLastAppVersion}     | ${"ENABLED"}      | ${"ENABLED"}
   `(
     "should resolve to an $case",
     async ({
       _,
       lastAppVersion,
       expectedLastAppVersion,
-      isReminderEnabled,
-      expectedIsReminderEnabled
+      reminderStatus,
+      expectedReminderStatus
     }) => {
       const containerMock = ({
         items: {
@@ -74,7 +74,7 @@ describe("findLastVersionByModelId", () => {
                   {
                     ...aRetrievedProfile,
                     lastAppVersion,
-                    isReminderEnabled
+                    reminderStatus
                   }
                 ]
               })
@@ -100,7 +100,7 @@ describe("findLastVersionByModelId", () => {
           },
           // we make sure that last optional properties added are with default values
           lastAppVersion: expectedLastAppVersion,
-          isReminderEnabled: expectedIsReminderEnabled
+          reminderStatus: expectedReminderStatus
         });
       }
     }

--- a/src/models/profile.ts
+++ b/src/models/profile.ts
@@ -17,6 +17,7 @@ import { FiscalCode } from "../../generated/definitions/FiscalCode";
 import { IsEmailEnabled } from "../../generated/definitions/IsEmailEnabled";
 import { IsEmailValidated } from "../../generated/definitions/IsEmailValidated";
 import { IsInboxEnabled } from "../../generated/definitions/IsInboxEnabled";
+import { IsReminderEnabled } from "../../generated/definitions/IsReminderEnabled";
 import { IsTestProfile } from "../../generated/definitions/IsTestProfile";
 import { IsWebhookEnabled } from "../../generated/definitions/IsWebhookEnabled";
 import { ServicesPreferencesModeEnum } from "../../generated/definitions/ServicesPreferencesMode";
@@ -99,6 +100,9 @@ export const Profile = t.intersection([
 
     // whether to store the content of messages sent to this citizen
     isInboxEnabled: IsInboxEnabled,
+
+    // opt-in flag for reminder functionality (defaults to false)
+    isReminderEnabled: IsReminderEnabled,
 
     // if true this profile is only for test purpose
     isTestProfile: IsTestProfile,

--- a/src/models/profile.ts
+++ b/src/models/profile.ts
@@ -101,9 +101,6 @@ export const Profile = t.intersection([
     // whether to store the content of messages sent to this citizen
     isInboxEnabled: IsInboxEnabled,
 
-    // opt-in flag for reminder functionality (defaults to false)
-    reminderStatus: ReminderStatus,
-
     // if true this profile is only for test purpose
     isTestProfile: IsTestProfile,
 
@@ -118,7 +115,10 @@ export const Profile = t.intersection([
 
     // array of user's preferred languages in ISO-3166-1-2 format
     // https://it.wikipedia.org/wiki/ISO_3166-2
-    preferredLanguages: PreferredLanguages
+    preferredLanguages: PreferredLanguages,
+
+    // opt-in flag for reminder functionality (defaults to false)
+    reminderStatus: ReminderStatus
   })
 ]);
 

--- a/src/models/profile.ts
+++ b/src/models/profile.ts
@@ -17,13 +17,13 @@ import { FiscalCode } from "../../generated/definitions/FiscalCode";
 import { IsEmailEnabled } from "../../generated/definitions/IsEmailEnabled";
 import { IsEmailValidated } from "../../generated/definitions/IsEmailValidated";
 import { IsInboxEnabled } from "../../generated/definitions/IsInboxEnabled";
-import { IsReminderEnabled } from "../../generated/definitions/IsReminderEnabled";
 import { IsTestProfile } from "../../generated/definitions/IsTestProfile";
 import { IsWebhookEnabled } from "../../generated/definitions/IsWebhookEnabled";
 import { ServicesPreferencesModeEnum } from "../../generated/definitions/ServicesPreferencesMode";
 import { PreferredLanguages } from "../../generated/definitions/PreferredLanguages";
 
 import { wrapWithKind } from "../utils/types";
+import { ReminderStatus } from "../../generated/definitions/ReminderStatus";
 
 export const PROFILE_COLLECTION_NAME = "profiles";
 export const PROFILE_MODEL_PK_FIELD = "fiscalCode" as const;
@@ -102,7 +102,7 @@ export const Profile = t.intersection([
     isInboxEnabled: IsInboxEnabled,
 
     // opt-in flag for reminder functionality (defaults to false)
-    isReminderEnabled: IsReminderEnabled,
+    reminderStatus: ReminderStatus,
 
     // if true this profile is only for test purpose
     isTestProfile: IsTestProfile,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Added `reminderStatus` property with an `UNSET` default to `profile` model
- Added `reminderStatus` openapi specs
- Added `reminder_status` to `Profile` and `ExtendedProfile` openapi specs 
- Added tests

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to allow user to express his will about opting in to reminder feature.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- yarn build
- yarn lint
- yarn test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
