### PR TITLE
[#IOCIT-112] Removed UNSET value from API specs of Reminder Status

### DIFF
--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -774,10 +774,8 @@ IsEmailEnabled:
 ReminderStatus:
   type: string
   x-extensible-enum:
-    - UNSET
     - ENABLED
     - DISABLED
-  default: UNSET
   example: ENABLED
   description:
     Api definition of reminder opt-in status

--- a/src/models/profile.ts
+++ b/src/models/profile.ts
@@ -118,7 +118,10 @@ export const Profile = t.intersection([
     preferredLanguages: PreferredLanguages,
 
     // opt-in flag for reminder functionality (defaults to UNSET)
-    reminderStatus: ReminderStatus
+    reminderStatus: withDefault(
+      t.union([ReminderStatus, t.literal("UNSET")]),
+      "UNSET"
+    )
   })
 ]);
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Removed UNSET value from API specs of Reminder Status and kept it as a model's only property value.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We don't want the mobile app to deal with the UNSET value. Mobile app will receive an `undefined` when no reminder status has been set while model on cosmos db will track the new property for every profile by setting an `UNSET` default.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* yarn build
* yarn test
* yarn lint

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
