### PR TITLE
[ICC-200] Adding ttl to CosmosRecource

### DIFF
--- a/__integrations__/utils/cosmosdb_model.test.ts
+++ b/__integrations__/utils/cosmosdb_model.test.ts
@@ -14,6 +14,7 @@ import {
 
 import { CosmosdbModelVersioned, RetrievedVersionedModel } from "../../src/utils/cosmosdb_model_versioned";
 import { createContext } from "../models/cosmos_utils";
+import { NonNegativeNumber } from "@pagopa/ts-commons/lib/numbers";
 
 const MyDocument = t.intersection([t.interface({
   pk: t.string,
@@ -78,7 +79,7 @@ const aDocument = {
 const aDocumentWithTtl = {
   ...aDocument,
   id: anotherTestId,
-  ttl: 300
+  ttl: 300 as NonNegativeNumber
 }
 
 const errorResponse: ErrorResponse = new Error();

--- a/__integrations__/utils/cosmosdb_model.test.ts
+++ b/__integrations__/utils/cosmosdb_model.test.ts
@@ -12,15 +12,21 @@ import {
   CosmosResource
 } from "../../src/utils/cosmosdb_model";
 
-import { CosmosdbModelVersioned, RetrievedVersionedModel } from "../../src/utils/cosmosdb_model_versioned";
+import {
+  CosmosdbModelVersioned,
+  RetrievedVersionedModel
+} from "../../src/utils/cosmosdb_model_versioned";
 import { createContext } from "../models/cosmos_utils";
 import { NonNegativeNumber } from "@pagopa/ts-commons/lib/numbers";
 
-const MyDocument = t.intersection([t.interface({
-  pk: t.string,
-  id: t.string,
-  test: t.string,
-}), t.partial({messageId: t.string})]);
+const MyDocument = t.intersection([
+  t.interface({
+    pk: t.string,
+    id: t.string,
+    test: t.string
+  }),
+  t.partial({ messageId: t.string })
+]);
 type MyDocument = t.TypeOf<typeof MyDocument>;
 
 const NewMyDocument = t.intersection([MyDocument, BaseModel]);
@@ -39,8 +45,13 @@ class MyModel extends CosmosdbModel<
   }
 }
 
-const RetrievedMyVersionedDocument = t.intersection([MyDocument, RetrievedVersionedModel]);
-type RetrievedMyVersionedDocument = t.TypeOf<typeof RetrievedMyVersionedDocument>;
+const RetrievedMyVersionedDocument = t.intersection([
+  MyDocument,
+  RetrievedVersionedModel
+]);
+type RetrievedMyVersionedDocument = t.TypeOf<
+  typeof RetrievedMyVersionedDocument
+>;
 
 class MyVersionedModel extends CosmosdbModelVersioned<
   MyDocument,
@@ -48,8 +59,8 @@ class MyVersionedModel extends CosmosdbModelVersioned<
   RetrievedMyVersionedDocument,
   "id",
   "pk"
->{
-  constructor(c: Container){
+> {
+  constructor(c: Container) {
     super(c, NewMyDocument, RetrievedMyVersionedDocument, "id", "pk");
   }
 }
@@ -80,7 +91,7 @@ const aDocumentWithTtl = {
   ...aDocument,
   id: anotherTestId,
   ttl: 300 as NonNegativeNumber
-}
+};
 
 const errorResponse: ErrorResponse = new Error();
 // eslint-disable-next-line functional/immutable-data
@@ -89,7 +100,6 @@ errorResponse.code = 500;
 jest.setTimeout(60000);
 
 describe("create", () => {
-
   it("should create a document", async () => {
     const context = createContext("id");
     await context.init();
@@ -102,6 +112,7 @@ describe("create", () => {
           ...aDocument
         })
       );
+      expect(result.right).not.toHaveProperty("ttl");
     }
     context.dispose();
   });
@@ -124,7 +135,6 @@ describe("create", () => {
 });
 
 describe("upsert", () => {
-
   it("should create a document", async () => {
     const context = createContext("id");
     await context.init();
@@ -137,6 +147,7 @@ describe("upsert", () => {
           ...aDocument
         })
       );
+      expect(result.right).not.toHaveProperty("ttl");
     }
     context.dispose();
   });
@@ -156,11 +167,9 @@ describe("upsert", () => {
     }
     context.dispose();
   });
-
 });
 
 describe("find", () => {
-
   it("should retrieve an existing document with ttl", async () => {
     const context = createContext("id");
     await context.init();
@@ -252,16 +261,18 @@ describe("find", () => {
       test: "test"
     })();
 
-    const result = await model.findAllVersionsByPartitionKey([testId, testPartition])();
+    const result = await model.findAllVersionsByPartitionKey([
+      testId,
+      testPartition
+    ])();
 
     expect(E.isRight(result)).toBeTruthy();
     if (E.isRight(result)) {
       // expect(O.isNone(result.right)).toBeTruthy();
-      expect(result.right).toHaveLength(2)
+      expect(result.right).toHaveLength(2);
     }
     context.dispose();
   });
-
 });
 
 /**************** @zeit/cosmosdb-server do not support "patch" yet *****************/
@@ -319,4 +330,3 @@ describe("find", () => {
 //     )()
 //   })
 // })
-

--- a/__integrations__/utils/cosmosdb_model.test.ts
+++ b/__integrations__/utils/cosmosdb_model.test.ts
@@ -77,6 +77,7 @@ const aDocument = {
 
 const aDocumentWithTtl = {
   ...aDocument,
+  id: anotherTestId,
   ttl: 300
 }
 
@@ -86,13 +87,11 @@ errorResponse.code = 500;
 
 jest.setTimeout(60000);
 
-const context = createContext("id");
-
-beforeEach(async () => await context.init())
-
 describe("create", () => {
 
   it("should create a document", async () => {
+    const context = createContext("id");
+    await context.init();
     const model = new MyModel(context.container);
     const result = await model.create(aDocument)();
     expect(E.isRight(result));
@@ -103,9 +102,12 @@ describe("create", () => {
         })
       );
     }
+    context.dispose();
   });
 
   it("should create a document with ttl", async () => {
+    const context = createContext("id");
+    await context.init();
     const model = new MyModel(context.container);
     const result = await model.create(aDocumentWithTtl)();
     expect(E.isRight(result));
@@ -116,13 +118,15 @@ describe("create", () => {
         })
       );
     }
+    context.dispose();
   });
-
 });
 
 describe("upsert", () => {
 
   it("should create a document", async () => {
+    const context = createContext("id");
+    await context.init();
     const model = new MyModel(context.container);
     const result = await model.upsert(aDocument)();
     expect(E.isRight(result));
@@ -133,9 +137,12 @@ describe("upsert", () => {
         })
       );
     }
+    context.dispose();
   });
 
   it("should create a document with ttl", async () => {
+    const context = createContext("id");
+    await context.init();
     const model = new MyModel(context.container);
     const result = await model.upsert(aDocumentWithTtl)();
     expect(E.isRight(result));
@@ -146,6 +153,7 @@ describe("upsert", () => {
         })
       );
     }
+    context.dispose();
   });
 
 });
@@ -153,9 +161,11 @@ describe("upsert", () => {
 describe("find", () => {
 
   it("should retrieve an existing document with ttl", async () => {
+    const context = createContext("id");
+    await context.init();
     const model = new MyModel(context.container);
     await model.create(aDocumentWithTtl)();
-    const result = await model.find([testId])();
+    const result = await model.find([anotherTestId])();
     expect(E.isRight(result)).toBeTruthy();
     if (E.isRight(result)) {
       expect(O.isSome(result.right)).toBeTruthy();
@@ -165,9 +175,12 @@ describe("find", () => {
         })
       );
     }
+    context.dispose();
   });
 
   it("should retrieve an existing document", async () => {
+    const context = createContext("id");
+    await context.init();
     const model = new MyModel(context.container);
     await model.create(aDocument)();
     const result = await model.find([testId])();
@@ -180,6 +193,7 @@ describe("find", () => {
         })
       );
     }
+    context.dispose();
   });
 
   it("should retrieve an existing document for a model with a partition", async () => {
@@ -202,6 +216,8 @@ describe("find", () => {
   });
 
   it("should return an empty option if the document does not exist", async () => {
+    const context = createContext("id");
+    await context.init();
     const model = new MyModel(context.container);
     await model.create(aDocument)();
     const result = await model.find([anotherTestId])();
@@ -209,9 +225,12 @@ describe("find", () => {
     if (E.isRight(result)) {
       expect(O.isNone(result.right)).toBeTruthy();
     }
+    context.dispose();
   });
 
-  it("should return 3 documents", async () => {
+  it("should return all documents belonging to the same partition key", async () => {
+    const context = createContext("id");
+    await context.init();
     const model = new MyVersionedModel(context.container);
 
     await model.upsert({
@@ -239,11 +258,10 @@ describe("find", () => {
       // expect(O.isNone(result.right)).toBeTruthy();
       expect(result.right).toHaveLength(2)
     }
+    context.dispose();
   });
 
 });
-
-afterEach(() => context.dispose())
 
 /**************** @zeit/cosmosdb-server do not support "patch" yet *****************/
 // const anotherTest = "another-test";
@@ -280,6 +298,7 @@ afterEach(() => context.dispose())
 // cannot run this test cause of patch support missing, this test was a success with a cosmos db inside io-d-comos-free
 // describe("Update ttl", () => {
 //   it("should find all version of a message", async () => {
+//     const context = createContext("id");
 //     const model = new MyVersionedModel(context.container);
 //     await model.upsert({
 //       id: testId,

--- a/src/utils/__tests__/cosmosdb_model.test.ts
+++ b/src/utils/__tests__/cosmosdb_model.test.ts
@@ -7,6 +7,7 @@ import { Container, ErrorResponse, ResourceResponse } from "@azure/cosmos";
 
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { BaseModel, CosmosdbModel, CosmosResource } from "../cosmosdb_model";
+import { NonNegativeNumber } from "@pagopa/ts-commons/lib/numbers";
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -375,3 +376,32 @@ describe("patch", () => {
     }
   });
 });
+
+describe("updateTTL", () => {
+
+  it("should add a ttl field", async () => {
+    containerMock.item.mockReturnValueOnce({ patch: patchMock });
+
+    patchMock.mockImplementationOnce(() =>
+      Promise.resolve({
+        resource: {
+          ...aDocument,
+          ...someMetadata,
+          test: anotherTest,
+          ttl: 300
+        }
+      })
+    )
+
+    const model = new MyModel(container);
+    const result = await model.updateTTL([testId], 300 as NonNegativeNumber)();
+
+    expect(patchMock).toBeCalledTimes(1);
+    expect(E.isRight(result)).toBeTruthy();
+    if (E.isRight(result)) {
+      expect(patchMock).toHaveBeenCalledWith(expect.objectContaining({"operations": [{"op": "add", "path": "/ttl", "value": 300}]}), undefined);
+      expect(patchMock).toHaveReturnedTimes(1);
+    }
+  })
+
+})

--- a/src/utils/cosmosdb_model.ts
+++ b/src/utils/cosmosdb_model.ts
@@ -33,9 +33,12 @@ export type CosmosDocumentIdKey = typeof CosmosDocumentIdKey;
 
 // For basic models, the identity field is always the id of cosmos
 export type BaseModel = t.TypeOf<typeof BaseModel>;
-export const BaseModel = t.interface({
-  id: NonEmptyString
-});
+export const BaseModel = t.intersection([
+  t.interface({
+    id: NonEmptyString
+  }),
+  t.partial({ ttl: NonNegativeNumber })
+]);
 
 // The set of keys for a model
 // T might not include base model fields ("id"), but we know they are mandatory in cosmos documents
@@ -72,7 +75,6 @@ export type CosmosResource = t.TypeOf<typeof CosmosResource>;
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 export const CosmosResource = t.intersection([
   BaseModel,
-  t.partial({ ttl: NonNegativeNumber }),
   t.interface({
     _etag: t.string,
     _rid: t.string,
@@ -81,9 +83,7 @@ export const CosmosResource = t.intersection([
   })
   // this cast is used to keep CosmosResource aligned
   // with @azure/cosmos/Resource type definition
-]) as t.Type<
-  Resource & { readonly id: NonEmptyString; readonly ttl?: NonNegativeNumber }
->;
+]) as t.Type<Resource & { readonly id: NonEmptyString }>;
 
 // An empty response from a Cosmos operation
 export const CosmosEmptyResponse = {

--- a/src/utils/cosmosdb_model.ts
+++ b/src/utils/cosmosdb_model.ts
@@ -227,7 +227,7 @@ export abstract class CosmosdbModel<
    */
   public patch(
     searchKey: DocumentSearchKey<TR, CosmosDocumentIdKey, PartitionKey>,
-    partialDocument: Partial<T>,
+    partialDocument: Partial<TR>,
     condition?: string,
     options?: RequestOptions
   ): TE.TaskEither<CosmosErrors, TR> {
@@ -279,7 +279,7 @@ export abstract class CosmosdbModel<
     // this cast was necessary even making patch accept a Partial<TR>
     return this.patch(searchKey, { ttl } as {
       readonly ttl: NonNegativeNumber;
-    } & T);
+    } & TR);
   }
 
   /**

--- a/src/utils/cosmosdb_model.ts
+++ b/src/utils/cosmosdb_model.ts
@@ -40,6 +40,9 @@ export const BaseModel = t.intersection([
   t.partial({ ttl: NonNegativeNumber })
 ]);
 
+export const ReadonlyBaseModel = t.readonly(BaseModel);
+export type ReadonlyBaseModel = t.TypeOf<typeof ReadonlyBaseModel>;
+
 // The set of keys for a model
 // T might not include base model fields ("id"), but we know they are mandatory in cosmos documents
 // Quick win would be to narrow T to extend BaseModel, but that way we'd lose usage flexibility
@@ -83,7 +86,7 @@ export const CosmosResource = t.intersection([
   })
   // this cast is used to keep CosmosResource aligned
   // with @azure/cosmos/Resource type definition
-]) as t.Type<Resource & { readonly id: NonEmptyString }>;
+]) as t.Type<Resource & ReadonlyBaseModel>;
 
 // An empty response from a Cosmos operation
 export const CosmosEmptyResponse = {

--- a/src/utils/cosmosdb_model.ts
+++ b/src/utils/cosmosdb_model.ts
@@ -276,6 +276,7 @@ export abstract class CosmosdbModel<
     searchKey: DocumentSearchKey<TR, CosmosDocumentIdKey, PartitionKey>,
     ttl: NonNegativeNumber
   ): TE.TaskEither<CosmosErrors, TR> {
+    // this cast was necessary even making patch accept a Partial<TR>
     return this.patch(searchKey, { ttl } as {
       readonly ttl: NonNegativeNumber;
     } & T);

--- a/src/utils/cosmosdb_model_versioned.ts
+++ b/src/utils/cosmosdb_model_versioned.ts
@@ -188,7 +188,7 @@ export abstract class CosmosdbModelVersioned<
       TE.map(
         RA.map(document =>
           super.updateTTL(
-            ([document.id, partitionKey] as unknown) as DocumentSearchKey<
+            [document.id, partitionKey] as DocumentSearchKey<
               TR,
               CosmosDocumentIdKey,
               PartitionKey

--- a/src/utils/cosmosdb_model_versioned.ts
+++ b/src/utils/cosmosdb_model_versioned.ts
@@ -228,7 +228,7 @@ export abstract class CosmosdbModelVersioned<
           ),
         toCosmosErrorResponse
       ),
-      TE.map(dbResponse => dbResponse[0])
+      TE.map(RA.flatten)
     );
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
* Add `ttl` property to `CosmosResource`
* Add `updateTTL` method to `CosmosdbModel`
* Add `updateTTLForAllVersions` method to `CosmosdbModelVersioned`
* Add `findAllVersionsByPartitionKey` method to `CosmosdbModelVersioned`
* Add integration tests
* Refactored integration tests inside `utils/cosmosdb_model.test.ts`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
those changes are needed in order to handle `ttl` with cosmos.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Integration test.
`NB:`
`@zeit/cosmosdb-server` does not support `patch` so I have tested `updateTTL` and `updateTTLForAllVersions` using `io-d-cosmos-free`, then i have commented the test.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
