### PR TITLE
[#IOCIT-137] Add pushNotificationsContentType optional field to the profile model

### DIFF
--- a/__integrations__/models/profile.test.ts
+++ b/__integrations__/models/profile.test.ts
@@ -7,7 +7,8 @@ import {
   PROFILE_MODEL_PK_FIELD,
   ProfileModel,
   PROFILE_SERVICE_PREFERENCES_SETTINGS_LEGACY_VERSION,
-  NewProfile
+  NewProfile,
+  RetrievedProfile
 } from "../../src/models/profile";
 import { createContext } from "./cosmos_utils";
 import { fromOption } from "fp-ts/lib/Either";
@@ -471,6 +472,43 @@ describe("Models |> Profile", () => {
             fail(`Should not have failed with reminderStatus = ${inputValue}`),
           _ => {
             expect(_.reminderStatus).toBe(expectedValue);
+          }
+        )
+      )();
+
+      context.dispose();
+    }
+  );
+
+  it.each`
+    inputValue     | expectedValue
+    ${undefined}   | ${"UNSET"}
+    ${"FULL"}      | ${"FULL"}
+    ${"ANONYMOUS"} | ${"ANONYMOUS"}
+  `(
+    "should save records when passing consistent pushNotificationsContentType= $inputValue",
+    async ({ inputValue, expectedValue }) => {
+      const context = createContext(PROFILE_MODEL_PK_FIELD);
+      await context.init();
+      const model = new ProfileModel(context.container);
+
+      const toBeSavedProfile: NewProfile = {
+        kind: "INewProfile" as const,
+        ...aProfile,
+        pushNotificationsContentType: inputValue
+      };
+
+      await pipe(
+        model.create(toBeSavedProfile),
+        te.bimap(
+          _ =>
+            fail(
+              `Should not have failed with pushNotificationsContentType= ${inputValue}`
+            ),
+          (retrievedProfile: RetrievedProfile) => {
+            expect(retrievedProfile.pushNotificationsContentType).toBe(
+              expectedValue
+            );
           }
         )
       )();

--- a/__integrations__/models/profile.test.ts
+++ b/__integrations__/models/profile.test.ts
@@ -483,6 +483,7 @@ describe("Models |> Profile", () => {
   it.each`
     inputValue     | expectedValue
     ${undefined}   | ${"UNSET"}
+    ${"UNSET"}     | ${"UNSET"}
     ${"FULL"}      | ${"FULL"}
     ${"ANONYMOUS"} | ${"ANONYMOUS"}
   `(

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -693,6 +693,8 @@ Profile:
       $ref: "#/ReminderStatus"
     last_app_version:
       $ref: "#/AppVersion"
+    push_notifications_content_type:
+      $ref: "#/PushNotificationsContentType"
     version:
       type: integer
   required:
@@ -742,6 +744,8 @@ ExtendedProfile:
       $ref: "#/IsTestProfile"
     last_app_version:
       $ref: "#/AppVersion"
+    push_notifications_content_type:
+      $ref: "#/PushNotificationsContentType"
     version:
       type: integer
   required:
@@ -788,6 +792,15 @@ AppVersion:
   pattern: '^((0|[1-9]\\d*)\\.){2}(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)){0,1}$'
   description: A string field in Semantic Versioning format
   example: "1.10.11"
+PushNotificationsContentType:
+  type: string
+  x-extensible-enum:
+    - FULL
+    - ANONYMOUS
+  example: FULL
+  description: |-
+    This parameter specifies how a specific user wants to visualize push notifications.
+    FULL leads to descriptive push notifications while ANONYMOUS leads to silent ones.
 TimeToLiveSeconds:
   type: integer
   default: 3600

--- a/src/models/__tests__/profile.test.ts
+++ b/src/models/__tests__/profile.test.ts
@@ -366,12 +366,7 @@ describe("createProfile", () => {
             0 as NonNegativeInteger
           ),
           version: 0,
-          // the decoder here sets the field to UNSET for undefined values
-          pushNotificationsContentType:
-            newProfileWithNotificationsContentType.pushNotificationsContentType !==
-            undefined
-              ? newProfileWithNotificationsContentType.pushNotificationsContentType
-              : "UNSET"
+          pushNotificationsContentType: expectedPushNotificationsContentType
         }),
         expect.anything()
       );

--- a/src/models/__tests__/profile.test.ts
+++ b/src/models/__tests__/profile.test.ts
@@ -510,6 +510,20 @@ describe("updateProfile", () => {
         pushNotificationsContentType
       })();
 
+      expect(containerMock.items.create).toBeCalledTimes(1);
+      expect(containerMock.items.create).toBeCalledWith(
+        expect.objectContaining({
+          version: 1,
+          pushNotificationsContentType: expectedPushNotificationsContentType,
+          kind: "INewProfile",
+          id: generateVersionedModelId<Profile, "fiscalCode">(
+            aRetrievedProfile.fiscalCode,
+            1 as NonNegativeInteger
+          ),
+          fiscalCode: aRetrievedProfile.fiscalCode
+        }),
+        expect.anything()
+      );
       expect(E.isRight(result)).toBeTruthy();
       if (E.isRight(result)) {
         expect(result.right).toEqual({

--- a/src/models/__tests__/profile.test.ts
+++ b/src/models/__tests__/profile.test.ts
@@ -17,6 +17,7 @@ import {
 import { Container } from "@azure/cosmos";
 import { ServicesPreferencesModeEnum } from "../../../generated/definitions/ServicesPreferencesMode";
 import { pipe } from "fp-ts/lib/function";
+import { generateVersionedModelId } from "../../utils/cosmosdb_model_versioned";
 
 const aFiscalCode = "FRLFRC74E04B157I" as FiscalCode;
 
@@ -355,6 +356,25 @@ describe("createProfile", () => {
         newProfileWithNotificationsContentType
       )();
 
+      expect(containerMock.items.create).toBeCalledTimes(1);
+      expect(containerMock.items.create).toBeCalledWith(
+        expect.objectContaining({
+          kind: newProfileWithNotificationsContentType.kind,
+          fiscalCode: newProfileWithNotificationsContentType.fiscalCode,
+          id: generateVersionedModelId<Profile, "fiscalCode">(
+            newProfileWithNotificationsContentType.fiscalCode,
+            0 as NonNegativeInteger
+          ),
+          version: 0,
+          // the decoder here sets the field to UNSET for undefined values
+          pushNotificationsContentType:
+            newProfileWithNotificationsContentType.pushNotificationsContentType !==
+            undefined
+              ? newProfileWithNotificationsContentType.pushNotificationsContentType
+              : "UNSET"
+        }),
+        expect.anything()
+      );
       expect(E.isRight(result)).toBeTruthy();
       if (E.isRight(result)) {
         expect(result.right).toEqual({

--- a/src/models/__tests__/profile.test.ts
+++ b/src/models/__tests__/profile.test.ts
@@ -115,6 +115,7 @@ describe("findLastVersionByModelId", () => {
   it.each`
     case                                                              | pushNotificationsContentType | expectedPushNotificationsContentType
     ${"existing profile with pushNotificationsContentType empty"}     | ${undefined}                 | ${"UNSET"}
+    ${"existing profile with pushNotificationsContentType UNSET"}     | ${"UNSET"}                   | ${"UNSET"}
     ${"existing profile with pushNotificationsContentType FULL"}      | ${"FULL"}                    | ${"FULL"}
     ${"existing profile with pushNotificationsContentType ANONYMOUS"} | ${"ANONYMOUS"}               | ${"ANONYMOUS"}
   `(

--- a/src/models/__tests__/profile.test.ts
+++ b/src/models/__tests__/profile.test.ts
@@ -50,6 +50,15 @@ const aRetrievedProfile: RetrievedProfile = {
 
 const aLastAppVersion = "1.0.0";
 
+const newProfile: NewProfile = {
+  kind: "INewProfile",
+  ...aRawProfile,
+  servicePreferencesSettings: {
+    mode: ServicesPreferencesModeEnum.LEGACY,
+    version: -1
+  }
+};
+
 describe("findLastVersionByModelId", () => {
   it.each`
     case                                                           | lastAppVersion     | expectedLastAppVersion | reminderStatus | expectedReminderStatus
@@ -126,7 +135,6 @@ describe("findLastVersionByModelId", () => {
     }) => {
       const containerMock = ({
         items: {
-          create: jest.fn(),
           query: jest.fn(() => ({
             fetchAll: jest.fn(() =>
               Promise.resolve({
@@ -233,15 +241,6 @@ describe("Profile codec", () => {
 });
 
 describe("createProfile", () => {
-  const newProfile: NewProfile = {
-    kind: "INewProfile",
-    ...aRawProfile,
-    servicePreferencesSettings: {
-      mode: ServicesPreferencesModeEnum.LEGACY,
-      version: -1
-    }
-  };
-
   it("should create a new profile", async () => {
     const containerMock = ({
       items: {
@@ -320,6 +319,51 @@ describe("createProfile", () => {
       expect(result.left.kind).toEqual("COSMOS_EMPTY_RESPONSE");
     }
   });
+
+  it.each`
+    case                                                              | pushNotificationsContentType | expectedPushNotificationsContentType
+    ${"existing profile with pushNotificationsContentType empty"}     | ${undefined}                 | ${"UNSET"}
+    ${"existing profile with pushNotificationsContentType UNSET"}     | ${"UNSET"}                   | ${"UNSET"}
+    ${"existing profile with pushNotificationsContentType FULL"}      | ${"FULL"}                    | ${"FULL"}
+    ${"existing profile with pushNotificationsContentType ANONYMOUS"} | ${"ANONYMOUS"}               | ${"ANONYMOUS"}
+  `(
+    "should create a profile with pushNotificationsContentType=$expectedPushNotificationsContentType when passing $pushNotificationsContentType",
+    async ({
+      pushNotificationsContentType,
+      expectedPushNotificationsContentType
+    }) => {
+      const containerMock = ({
+        items: {
+          create: jest.fn().mockReturnValue(
+            Promise.resolve({
+              resource: {
+                ...aRetrievedProfile,
+                pushNotificationsContentType
+              }
+            })
+          )
+        }
+      } as unknown) as Container;
+
+      const model = new ProfileModel(containerMock);
+
+      const newProfileWithNotificationsContentType: NewProfile = {
+        ...newProfile,
+        pushNotificationsContentType
+      };
+      const result = await model.create(
+        newProfileWithNotificationsContentType
+      )();
+
+      expect(E.isRight(result)).toBeTruthy();
+      if (E.isRight(result)) {
+        expect(result.right).toEqual({
+          ...aRetrievedProfile,
+          pushNotificationsContentType: expectedPushNotificationsContentType
+        });
+      }
+    }
+  );
 });
 
 describe("updateProfile", () => {
@@ -412,4 +456,109 @@ describe("updateProfile", () => {
       expect(result.left.kind).toEqual("COSMOS_EMPTY_RESPONSE");
     }
   });
+
+  it.each`
+    case                                                              | pushNotificationsContentType | expectedPushNotificationsContentType
+    ${"existing profile with pushNotificationsContentType empty"}     | ${undefined}                 | ${"UNSET"}
+    ${"existing profile with pushNotificationsContentType UNSET"}     | ${"UNSET"}                   | ${"UNSET"}
+    ${"existing profile with pushNotificationsContentType FULL"}      | ${"FULL"}                    | ${"FULL"}
+    ${"existing profile with pushNotificationsContentType ANONYMOUS"} | ${"ANONYMOUS"}               | ${"ANONYMOUS"}
+  `(
+    "should update a profile and return the decoded pushNotificationsContentType",
+    async ({
+      pushNotificationsContentType,
+      expectedPushNotificationsContentType
+    }) => {
+      const containerMock = ({
+        items: {
+          create: jest.fn().mockReturnValue(
+            Promise.resolve({
+              resource: {
+                ...aRetrievedProfile,
+                pushNotificationsContentType,
+                version: 1
+              }
+            })
+          )
+        }
+      } as unknown) as Container;
+
+      const model = new ProfileModel(containerMock);
+
+      const result = await model.update({
+        ...aRetrievedProfile,
+        pushNotificationsContentType
+      })();
+
+      expect(E.isRight(result)).toBeTruthy();
+      if (E.isRight(result)) {
+        expect(result.right).toEqual({
+          ...aRetrievedProfile,
+          pushNotificationsContentType: expectedPushNotificationsContentType,
+          version: 1
+        });
+      }
+    }
+  );
+});
+
+describe("upsertProfile", () => {
+  it.each`
+    case                                                              | pushNotificationsContentType | expectedPushNotificationsContentType
+    ${"existing profile with pushNotificationsContentType empty"}     | ${undefined}                 | ${"UNSET"}
+    ${"existing profile with pushNotificationsContentType UNSET"}     | ${"UNSET"}                   | ${"UNSET"}
+    ${"existing profile with pushNotificationsContentType FULL"}      | ${"FULL"}                    | ${"FULL"}
+    ${"existing profile with pushNotificationsContentType ANONYMOUS"} | ${"ANONYMOUS"}               | ${"ANONYMOUS"}
+  `(
+    "should upsert a profile and return the decoded pushNotificationsContentType",
+    async ({
+      pushNotificationsContentType,
+      expectedPushNotificationsContentType
+    }) => {
+      const containerMock = ({
+        items: {
+          create: jest.fn().mockReturnValue(
+            Promise.resolve({
+              resource: {
+                ...aRetrievedProfile,
+                pushNotificationsContentType,
+                version: 1
+              }
+            })
+          ),
+          query: jest.fn().mockReturnValue({
+            fetchAll: jest.fn().mockReturnValue(
+              Promise.resolve({
+                resources: [
+                  {
+                    ...aRetrievedProfile,
+                    pushNotificationsContentType
+                  }
+                ]
+              })
+            )
+          })
+        }
+      } as unknown) as Container;
+
+      const model = new ProfileModel(containerMock);
+
+      const newProfileWithNotificationsContentType: NewProfile = {
+        ...newProfile,
+        pushNotificationsContentType
+      };
+      const result = await model.upsert(
+        newProfileWithNotificationsContentType
+      )();
+
+      expect(E.isRight(result)).toBeTruthy();
+      if (E.isRight(result)) {
+        expect(result.right).toEqual({
+          ...aRetrievedProfile,
+          pushNotificationsContentType: expectedPushNotificationsContentType,
+          version: 1
+        });
+      }
+    }
+  );
 });

--- a/src/models/profile.ts
+++ b/src/models/profile.ts
@@ -22,7 +22,7 @@ import { IsWebhookEnabled } from "../../generated/definitions/IsWebhookEnabled";
 import { ServicesPreferencesModeEnum } from "../../generated/definitions/ServicesPreferencesMode";
 import { PreferredLanguages } from "../../generated/definitions/PreferredLanguages";
 
-import { wrapWithKind } from "../utils/types";
+import { UNSET, UNSET_VALUE, wrapWithKind } from "../utils/types";
 import { ReminderStatus } from "../../generated/definitions/ReminderStatus";
 import { PushNotificationsContentType } from "../../generated/definitions/PushNotificationsContentType";
 
@@ -122,15 +122,12 @@ export const Profile = t.intersection([
     // FULL leads to descriptive push notifications while ANONYMOUS leads to silent ones.
     // (defaults to UNSET)
     pushNotificationsContentType: withDefault(
-      t.union([PushNotificationsContentType, t.literal("UNSET")]),
-      "UNSET"
+      t.union([PushNotificationsContentType, UNSET]),
+      UNSET_VALUE
     ),
 
     // opt-in flag for reminder functionality (defaults to UNSET)
-    reminderStatus: withDefault(
-      t.union([ReminderStatus, t.literal("UNSET")]),
-      "UNSET"
-    )
+    reminderStatus: withDefault(t.union([ReminderStatus, UNSET]), UNSET_VALUE)
   })
 ]);
 

--- a/src/models/profile.ts
+++ b/src/models/profile.ts
@@ -118,17 +118,17 @@ export const Profile = t.intersection([
     // https://it.wikipedia.org/wiki/ISO_3166-2
     preferredLanguages: PreferredLanguages,
 
-    // opt-in flag for reminder functionality (defaults to UNSET)
-    reminderStatus: withDefault(
-      t.union([ReminderStatus, t.literal("UNSET")]),
-      "UNSET"
-    ),
-
     // This parameter specifies how a specific user wants to visualize push notifications.
     // FULL leads to descriptive push notifications while ANONYMOUS leads to silent ones.
     // (defaults to UNSET)
     pushNotificationsContentType: withDefault(
       t.union([PushNotificationsContentType, t.literal("UNSET")]),
+      "UNSET"
+    ),
+
+    // opt-in flag for reminder functionality (defaults to UNSET)
+    reminderStatus: withDefault(
+      t.union([ReminderStatus, t.literal("UNSET")]),
       "UNSET"
     )
   })

--- a/src/models/profile.ts
+++ b/src/models/profile.ts
@@ -24,6 +24,7 @@ import { PreferredLanguages } from "../../generated/definitions/PreferredLanguag
 
 import { wrapWithKind } from "../utils/types";
 import { ReminderStatus } from "../../generated/definitions/ReminderStatus";
+import { PushNotificationsContentType } from "../../generated/definitions/PushNotificationsContentType";
 
 export const PROFILE_COLLECTION_NAME = "profiles";
 export const PROFILE_MODEL_PK_FIELD = "fiscalCode" as const;
@@ -120,6 +121,14 @@ export const Profile = t.intersection([
     // opt-in flag for reminder functionality (defaults to UNSET)
     reminderStatus: withDefault(
       t.union([ReminderStatus, t.literal("UNSET")]),
+      "UNSET"
+    ),
+
+    // This parameter specifies how a specific user wants to visualize push notifications.
+    // FULL leads to descriptive push notifications while ANONYMOUS leads to silent ones.
+    // (defaults to UNSET)
+    pushNotificationsContentType: withDefault(
+      t.union([PushNotificationsContentType, t.literal("UNSET")]),
       "UNSET"
     )
   })

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -2,6 +2,10 @@ import * as t from "io-ts";
 import * as E from "fp-ts/lib/Either";
 import { pipe } from "fp-ts/lib/function";
 
+export const UNSET = t.literal("UNSET");
+export type UNSET = t.TypeOf<typeof UNSET>;
+export const UNSET_VALUE: UNSET = "UNSET";
+
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function isDefined<T>(o: T | undefined | null): o is T {
   return o !== undefined && o !== null;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
* added `pushNotificationsContentType` optional field to the profile model
* added `push_notifications_content_type` optional field to the OpenAPI spec(in particular to the `Profile` and `ExtendedProfile` definitions)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
allow user to specify how to visualize the push notifications

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
build passed 
unit and integration tests passed

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
