### PR TITLE
[IOPID-1245] Remove fiscal code filter to avoid full table scan

### DIFF
--- a/src/utils/unique_email_enforcement/index.ts
+++ b/src/utils/unique_email_enforcement/index.ts
@@ -10,9 +10,7 @@ export const ProfileEmail = t.type({
 export type ProfileEmail = t.TypeOf<typeof ProfileEmail>;
 
 export interface IProfileEmailReader {
-  readonly list: (
-    filter: EmailString | FiscalCode
-  ) => AsyncIterableIterator<ProfileEmail>;
+  readonly list: (filter: EmailString) => AsyncIterableIterator<ProfileEmail>;
 }
 
 export interface IProfileEmailWriter {

--- a/src/utils/unique_email_enforcement/storage.ts
+++ b/src/utils/unique_email_enforcement/storage.ts
@@ -3,7 +3,7 @@ import * as t from "io-ts";
 import { flow } from "fp-ts/lib/function";
 
 import { TableClient, odata } from "@azure/data-tables";
-import { EmailString, FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import { EmailString } from "@pagopa/ts-commons/lib/strings";
 
 import {
   ProfileEmail,
@@ -38,13 +38,9 @@ export class DataTableProfileEmailsRepository
   constructor(private readonly tableClient: TableClient) {}
 
   // Generates an AsyncIterable<ProfileEmail>
-  public async *list(
-    filter: EmailString | FiscalCode
-  ): AsyncIterableIterator<ProfileEmail> {
+  public async *list(filter: EmailString): AsyncIterableIterator<ProfileEmail> {
     const queryOptions = {
-      filter: EmailString.is(filter)
-        ? odata`PartitionKey eq ${filter.toLowerCase()}`
-        : odata`RowKey eq ${filter}`
+      filter: odata`PartitionKey eq ${filter.toLowerCase()}`
     };
     const list = this.tableClient.listEntities({
       queryOptions


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
1. removed the possibility to filter the `uniqueEmails` table by its row key

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
filter a table for a row key is an expensive operation, that it is not justified by practical reasons

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
