### PR TITLE
[#IOPID-1197] Add get method to table storage model

### DIFF
--- a/src/utils/unique_email_enforcement/__tests__/index.test.ts
+++ b/src/utils/unique_email_enforcement/__tests__/index.test.ts
@@ -39,7 +39,8 @@ describe("isEmailAlreadyTaken", () => {
     ({ entries, expected }) => {
       const result = isEmailAlreadyTaken(mocks.email)({
         profileEmails: {
-          list: generateProfileEmails(entries)
+          list: generateProfileEmails(entries),
+          get: jest.fn()
         }
       });
       expect(result).resolves.toBe(expected);

--- a/src/utils/unique_email_enforcement/index.ts
+++ b/src/utils/unique_email_enforcement/index.ts
@@ -10,6 +10,7 @@ export const ProfileEmail = t.type({
 export type ProfileEmail = t.TypeOf<typeof ProfileEmail>;
 
 export interface IProfileEmailReader {
+  readonly get: (p: ProfileEmail) => Promise<ProfileEmail>;
   readonly list: (filter: EmailString) => AsyncIterableIterator<ProfileEmail>;
 }
 

--- a/src/utils/unique_email_enforcement/storage.ts
+++ b/src/utils/unique_email_enforcement/storage.ts
@@ -37,6 +37,26 @@ export class DataTableProfileEmailsRepository
   implements IProfileEmailReader, IProfileEmailWriter {
   constructor(private readonly tableClient: TableClient) {}
 
+  public async get(p: ProfileEmail): Promise<ProfileEmail> {
+    try {
+      const entity = await this.tableClient.getEntity(
+        p.email.toLowerCase(),
+        p.fiscalCode
+      );
+      const profileEmail = ProfileEmailToTableEntity.decode(entity);
+      if (E.isLeft(profileEmail)) {
+        throw new Error(`can't parse a profile email from the given entity`, {
+          cause: "parsing"
+        });
+      }
+      return profileEmail.right;
+    } catch {
+      throw new Error(
+        `unable to get a profile entity from ${this.tableClient.tableName} table`
+      );
+    }
+  }
+
   // Generates an AsyncIterable<ProfileEmail>
   public async *list(filter: EmailString): AsyncIterableIterator<ProfileEmail> {
     const queryOptions = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Added `get` method to `IProfileEmailReader` interface and to the `DataTableProfileEmailsRepository` implementation

#### Motivation and Context
This method is needed in the `OnProfileUpdate` function to get the entity from `(partitionKey, rowKey)`

#### How Has This Been Tested?
Through unit tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
