### PR TITLE
[#IOCOM-962] added configuration_id in ThirdPartyData as an ulid

### DIFF
--- a/openapi/__tests__/definitions.test.ts
+++ b/openapi/__tests__/definitions.test.ts
@@ -1006,6 +1006,30 @@ describe("ThirdPartyData", () => {
       })
     );
   });
+
+  it("should decode a ThirdPartyData with the right configurationId if provided", () => {
+    const aThirdPartyData = { id: aThirdPartyId, configuration_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV" };
+
+    const decoded = ThirdPartyData.decode(aThirdPartyData);
+
+    expect(decoded).toMatchObject(
+      expect.objectContaining({
+        _tag: "Right",
+        right: {
+          id: aThirdPartyId,
+          has_attachments: false,
+          has_remote_content: false,
+          configuration_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+        }
+      })
+    );
+  });
+
+  it("should fail to decode a ThirdPartyData if a wrong ulid is provided as configuration_id", () => {
+    const aThirdPartyData = { id: aThirdPartyId, configuration_id: "notAnUlid" };
+    const decoded = ThirdPartyData.decode(aThirdPartyData);
+    expect(E.isLeft(decoded)).toBeTruthy();
+  });
 });
 
 /**

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -214,10 +214,10 @@ ThirdPartyData:
       description: Unique id for retrieving third party enriched information about the message
       minLength: 1
     original_sender:
-        type: string
-        description: |-
-          Either a ServiceId or a simple string representing the sender name
-        minLength: 1
+      type: string
+      description: |-
+        Either a ServiceId or a simple string representing the sender name
+      minLength: 1
     original_receipt_date:
       $ref: "#/Timestamp"
     has_attachments:
@@ -235,6 +235,8 @@ ThirdPartyData:
     summary:
       type: string
       minLength: 1
+    configuration_id:
+      $ref: "#/Ulid"
   required:
     - id
 EUCovidCert:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- [added configuration_id in ThirdPartyData as an ulid](https://github.com/pagopa/io-functions-commons/commit/09d963e95af3372a778f6c1c2dd06f3b62f2ccf3)
- [added test for configuration_id in ThirdPartyData](https://github.com/pagopa/io-functions-commons/pull/356/commits/02a1b9092219c725ebfbb8a75f02cb3fc4a1567c)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Added an optional configuration id in the ThirdPartyData in order to make it possibile to be sent in the CreateMessage

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
