### PR TITLE
[IOCOM-1030] Extract userId from NewRCConfigurationBase

### DIFF
--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -559,10 +559,6 @@ RCConfigurationResponse:
 NewRCConfigurationBase:
   type: object
   properties:
-    userId: 
-      type: string
-      minLength: 1
-      description: User id.
     name:
       type: string
       minLength: 1
@@ -601,8 +597,13 @@ RCConfigurationBase:
             format: Ulid
             x-import: '@pagopa/ts-commons/lib/strings'
             example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          userId:
+            type: string
+            minLength: 1
+            description: User id.
         required:
           - configurationId
+          - userId
 
 RCConfigurationEnvironment:
   x-one-of: true

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -579,7 +579,6 @@ NewRCConfigurationBase:
       type: boolean
       description: Flag to check if lollipop is enabled
   required:
-    - userId
     - name
     - description
     - hasPrecondition


### PR DESCRIPTION
We need this property to be outside of NewRCConfigurationBase in order to manage operations of create and update

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

* [Extract userId from NewRCConfigurationBase](https://github.com/pagopa/io-functions-commons/commit/bb5e835ca4b0f8aafaa429733c58322c3a0fcf4d)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
