### PR TITLE
[#IOCOM-1074] Make RCConfigurationEnvironment optional

### DIFF
--- a/openapi/__tests__/definitions.test.ts
+++ b/openapi/__tests__/definitions.test.ts
@@ -1008,7 +1008,10 @@ describe("ThirdPartyData", () => {
   });
 
   it("should decode a ThirdPartyData with the right configurationId if provided", () => {
-    const aThirdPartyData = { id: aThirdPartyId, configuration_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV" };
+    const aThirdPartyData = {
+      id: aThirdPartyId,
+      configuration_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+    };
 
     const decoded = ThirdPartyData.decode(aThirdPartyData);
 
@@ -1026,7 +1029,10 @@ describe("ThirdPartyData", () => {
   });
 
   it("should fail to decode a ThirdPartyData if a wrong ulid is provided as configuration_id", () => {
-    const aThirdPartyData = { id: aThirdPartyId, configuration_id: "notAnUlid" };
+    const aThirdPartyData = {
+      id: aThirdPartyId,
+      configuration_id: "notAnUlid"
+    };
     const decoded = ThirdPartyData.decode(aThirdPartyData);
     expect(E.isLeft(decoded)).toBeTruthy();
   });

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -546,15 +546,10 @@ InternalMessageResponseWithContent:
   required:
     - message
 
-NewRCConfiguration:
+RCConfigurationPublic:
   allOf:
     - $ref: "#/NewRCConfigurationBase"
     - $ref: "#/RCConfigurationEnvironment"
-
-RCConfigurationResponse:
-  allOf:
-    - $ref: "#/RCConfigurationBase"
-    - $ref: "#/RCConfigurationEnvironmentResponse"
 
 NewRCConfigurationBase:
   type: object
@@ -598,46 +593,12 @@ RCConfigurationBase:
           - configuration_id
 
 RCConfigurationEnvironment:
-  x-one-of: true
-  allOf:
-    - $ref: "#/RCConfigurationWithTestEnvironment"
-    - $ref: "#/RCConfigurationWithProdEnvironment"
-    - $ref: "#/RCConfigurationWithProdAndTestEnvironment"
-
-RCConfigurationEnvironmentResponse:
   type: object
   properties:
     test_environment:
       $ref: "#/RCConfigurationTestEnvironment"
     prod_environment:
       $ref: "#/RCConfigurationProdEnvironment"
-
-RCConfigurationWithTestEnvironment:
-  type: object
-  properties:
-    test_environment:
-      $ref: "#/RCConfigurationTestEnvironment"
-  required:
-    - test_environment
-
-RCConfigurationWithProdEnvironment:
-  type: object
-  properties:
-    prod_environment:
-      $ref: "#/RCConfigurationProdEnvironment"
-  required:
-    - prod_environment
-
-RCConfigurationWithProdAndTestEnvironment:
-  type: object
-  properties:
-    prod_environment:
-      $ref: "#/RCConfigurationProdEnvironment"
-    test_environment:
-      $ref: "#/RCConfigurationTestEnvironment"
-  required:
-    - prod_environment
-    - test_environment
 
 RCConfigurationProdEnvironment:
   type: object
@@ -650,6 +611,7 @@ RCConfigurationProdEnvironment:
       $ref: "#/RCAuthenticationConfig"
   required:
     - base_url
+    - details_authentication
 
 RCAuthenticationConfig:
   type: object
@@ -702,6 +664,8 @@ RCConfigurationTestEnvironment:
           type: array
           items:
             $ref: "#/FiscalCode"
+      required:
+      - test_users
 
 MessageResponseWithContent:
   type: object

--- a/src/models/__tests__/rc_configuration.test.ts
+++ b/src/models/__tests__/rc_configuration.test.ts
@@ -127,9 +127,4 @@ describe("RC", () => {
     );
     expect(E.isRight(result)).toBeTruthy();
   });
-
-  it("GIVEN a not valid RC object with no environments WHEN the object is decoded THEN the decode fail", async () => {
-    const result = RCConfiguration.decode(aRemoteContentConfigurationWithNoEnv);
-    expect(E.isLeft(result)).toBeTruthy();
-  });
 });

--- a/src/models/rc_configuration.ts
+++ b/src/models/rc_configuration.ts
@@ -74,16 +74,8 @@ export type RCConfigurationBase = t.TypeOf<typeof RCConfigurationBase>;
 export type RCConfiguration = t.TypeOf<typeof RCConfiguration>;
 export const RCConfiguration = t.intersection([
   RCConfigurationBase,
-  t.union([
-    t.intersection([
-      t.interface({ prodEnvironment: RCEnvironmentConfig }),
-      t.partial({ testEnvironment: RCTestEnvironmentConfig })
-    ]),
-    t.intersection([
-      t.partial({ prodEnvironment: RCEnvironmentConfig }),
-      t.interface({ testEnvironment: RCTestEnvironmentConfig })
-    ])
-  ])
+  t.partial({ testEnvironment: RCTestEnvironmentConfig }),
+  t.partial({ prodEnvironment: RCEnvironmentConfig })
 ]);
 
 export const RetrievedRCConfiguration = t.intersection([

--- a/src/utils/rc_configuration.ts
+++ b/src/utils/rc_configuration.ts
@@ -1,8 +1,8 @@
 import { withoutUndefinedValues } from "@pagopa/ts-commons/lib/types";
+import { RCConfigurationPublic } from "../../generated/definitions/RCConfigurationPublic";
 import { RCAuthenticationConfig } from "../../generated/definitions/RCAuthenticationConfig";
 import { RCClientCert } from "../../generated/definitions/RCClientCert";
 import { RCConfigurationProdEnvironment } from "../../generated/definitions/RCConfigurationProdEnvironment";
-import { RCConfigurationResponse } from "../../generated/definitions/RCConfigurationResponse";
 import { RCConfigurationTestEnvironment } from "../../generated/definitions/RCConfigurationTestEnvironment";
 import {
   RCTestEnvironmentConfig,
@@ -41,28 +41,28 @@ const getProdEnvironment = (
   prodEnvironment: RCEnvironmentConfig
 ): RCConfigurationProdEnvironment => ({
   base_url: prodEnvironment.baseUrl,
-  details_authentication: prodEnvironment.detailsAuthentication
-    ? getDetailsAuthentication(prodEnvironment.detailsAuthentication)
-    : undefined
+  details_authentication: getDetailsAuthentication(
+    prodEnvironment.detailsAuthentication
+  )
 });
 
 /**
  * Converts a RetrievedRCConfiguration to a configuration that can be shared via API
  */
 export const retrievedRCConfigurationToPublic = (
-  retrievedConfiguration: RetrievedRCConfiguration
-): RCConfigurationResponse =>
+  publicConfiguration: RetrievedRCConfiguration
+): RCConfigurationPublic =>
   withoutUndefinedValues({
-    configuration_id: retrievedConfiguration.configurationId,
-    description: retrievedConfiguration.description,
-    disable_lollipop_for: retrievedConfiguration.disableLollipopFor,
-    has_precondition: retrievedConfiguration.hasPrecondition,
-    is_lollipop_enabled: retrievedConfiguration.isLollipopEnabled,
-    name: retrievedConfiguration.name,
-    prod_environment: retrievedConfiguration.prodEnvironment
-      ? getProdEnvironment(retrievedConfiguration.prodEnvironment)
+    configuration_id: publicConfiguration.configurationId,
+    description: publicConfiguration.description,
+    disable_lollipop_for: publicConfiguration.disableLollipopFor,
+    has_precondition: publicConfiguration.hasPrecondition,
+    is_lollipop_enabled: publicConfiguration.isLollipopEnabled,
+    name: publicConfiguration.name,
+    prod_environment: publicConfiguration.prodEnvironment
+      ? getProdEnvironment(publicConfiguration.prodEnvironment)
       : undefined,
-    test_environment: retrievedConfiguration.testEnvironment
-      ? getTestEnvironment(retrievedConfiguration.testEnvironment)
+    test_environment: publicConfiguration.testEnvironment
+      ? getTestEnvironment(publicConfiguration.testEnvironment)
       : undefined
   });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

* [Update definitions and fix unit test](https://github.com/pagopa/io-functions-commons/commit/f25b207da3d7783c82eda974eb571fb95282ee80);
* [Update rc-model in order to accept partial environment](https://github.com/pagopa/io-functions-commons/commit/b4c8bab06fd7cbe42b2af90faa11f95787f069ad);
* [Fix mappers](https://github.com/pagopa/io-functions-commons/commit/8ab0a6336e98ee9d6f82eeaaa14bfcd7f17e0b45).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We need to make those properties optional

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
