### PR TITLE
[IOCOM-1462] feat: Add organization fiscal code in EnrichedMessage

### DIFF
--- a/openapi/__tests__/definitions.test.ts
+++ b/openapi/__tests__/definitions.test.ts
@@ -23,7 +23,7 @@ import { CommonServiceMetadata as ApiCommonServiceMetadata } from "../../generat
 import { StandardServiceMetadata as ApiStandardServiceMetadata } from "../../generated/definitions/StandardServiceMetadata";
 import { ServiceScopeEnum } from "../../generated/definitions/ServiceScope";
 import { SpecialServiceCategoryEnum } from "../../generated/definitions/SpecialServiceCategory";
-import { NotRejectedMessageStatusValueEnum as MessageStatusValueEnum, NotRejectedMessageStatusValueEnum } from "../../generated/definitions/NotRejectedMessageStatusValue";
+import { NotRejectedMessageStatusValueEnum as MessageStatusValueEnum } from "../../generated/definitions/NotRejectedMessageStatusValue";
 import { MessageStatus } from "../../generated/definitions/MessageStatus";
 import { MessageStatusChange } from "../../generated/definitions/MessageStatusChange";
 import { MessageStatusAttributes } from "../../generated/definitions/MessageStatusAttributes";
@@ -33,14 +33,10 @@ import { Change_typeEnum as ReadingChangeType } from "../../generated/definition
 import { Change_typeEnum as ArchinvingChangeType } from "../../generated/definitions/MessageStatusArchivingChange";
 import { FeatureLevelTypeEnum } from "../../generated/definitions/FeatureLevelType";
 import { ThirdPartyMessage } from "../../generated/definitions/ThirdPartyMessage";
-import { BaseEnrichedMessage } from "../../generated/definitions/BaseEnrichedMessage"
-import { EnrichedMessageWithOrganizationFiscalCode } from "../../generated/definitions/EnrichedMessageWithOrganizationFiscalCode"
 import { NonEmptyString, Semver } from "@pagopa/ts-commons/lib/strings";
 
 import { AppVersion } from "../../generated/definitions/AppVersion";
 import { ThirdPartyData } from "../../generated/definitions/ThirdPartyData";
-import { aService } from "../../__mocks__/mocks";
-import { EnrichedMessage } from "../../generated/definitions/EnrichedMessage";
 
 describe("ServicePayload definition", () => {
   const commonServicePayload = {
@@ -235,67 +231,6 @@ const aContentWithThirdPartyData = {
 const aPayee: Payee = { fiscal_code: anOrganizationFiscalCode };
 
 const aThirdPartyId = "aThirdPartyId" as NonEmptyString;
-
-describe("BaseEnrichedMessage definition", () => {
-  it("should decode a BaseEnrichedMessage", () => {
-    const aBaseEnrichedMessage = {
-      ...aMessageWithoutContent,
-      service_name: "aService",
-      organization_name: aService.organizationName,
-      message_title: "aTitle",
-    };
-
-    expect(
-      E.isRight(BaseEnrichedMessage.decode(aBaseEnrichedMessage))
-    ).toBe(true);
-  });
-});
-
-describe("EnrichedMessage definition", () => {
-  it("should not fail decoding an EnrichedMessage with an organization fiscal code", () => {
-    const anEnrichedMessage = {
-      ...aMessageWithoutContent,
-      sender_service_id: "test" as NonEmptyString,
-      service_name: "aService",
-      organization_name: aService.organizationName,
-      organization_fiscal_code: aService.organizationFiscalCode,
-      message_title: "aTitle",
-    };
-
-    expect(
-      E.isRight(EnrichedMessage.decode(anEnrichedMessage))
-    ).toBe(true);
-  });
-});
-
-describe("EnrichedMessageWithOrganizationFiscalCode definition", () => {
-  it("should fail decoding a EnrichedMessageWithOrganizationFiscalCode if the organization fiscal code is not provided", () => {
-    const aBaseEnrichedMessageWithOrganizationFiscalCode = {
-      ...aMessageWithoutContent,
-      service_name: "aService",
-      organization_name: aService.organizationName,
-      message_title: "aTitle",
-    };
-
-    expect(
-      E.isLeft(EnrichedMessageWithOrganizationFiscalCode.decode(aBaseEnrichedMessageWithOrganizationFiscalCode))
-    ).toBe(true);
-  });
-
-  it("should decode correctly a EnrichedMessageWithOrganizationFiscalCode if the organization fiscal code is provided", () => {
-    const aBaseEnrichedMessage = {
-      ...aMessageWithoutContent,
-      service_name: "aService",
-      organization_name: aService.organizationName,
-      organization_fiscal_code: aService.organizationFiscalCode,
-      message_title: "aTitle",
-    };
-
-    expect(
-      E.isRight(EnrichedMessageWithOrganizationFiscalCode.decode(aBaseEnrichedMessage))
-    ).toBe(true);
-  });
-});
 
 describe("NewMessage definition", () => {
   it("should decode STANDARD NewMessage with content but without payment data", () => {

--- a/openapi/__tests__/definitions.test.ts
+++ b/openapi/__tests__/definitions.test.ts
@@ -33,10 +33,12 @@ import { Change_typeEnum as ReadingChangeType } from "../../generated/definition
 import { Change_typeEnum as ArchinvingChangeType } from "../../generated/definitions/MessageStatusArchivingChange";
 import { FeatureLevelTypeEnum } from "../../generated/definitions/FeatureLevelType";
 import { ThirdPartyMessage } from "../../generated/definitions/ThirdPartyMessage";
+import { EnrichedMessage } from "../../generated/definitions/EnrichedMessage";
 import { NonEmptyString, Semver } from "@pagopa/ts-commons/lib/strings";
 
 import { AppVersion } from "../../generated/definitions/AppVersion";
 import { ThirdPartyData } from "../../generated/definitions/ThirdPartyData";
+import { aService } from "../../__mocks__/mocks";
 
 describe("ServicePayload definition", () => {
   const commonServicePayload = {
@@ -231,6 +233,29 @@ const aContentWithThirdPartyData = {
 const aPayee: Payee = { fiscal_code: anOrganizationFiscalCode };
 
 const aThirdPartyId = "aThirdPartyId" as NonEmptyString;
+
+describe("EnrichedMessage", () => {
+  const aValidEnrichedMessage: EnrichedMessage = {
+    id: "A_MESSAGE_ID",
+    fiscal_code: aFiscalCode,
+    created_at: aDate,
+    sender_service_id: aMessageWithoutContent.sender_service_id as NonEmptyString,
+    service_name: "aService",
+    organization_name: aService.organizationName,
+    organization_fiscal_code: aService.organizationFiscalCode,
+    message_title: "aTitle",
+    is_read: false,
+    is_archived: false,
+  };
+
+  it("should correctly decode a valid EnrichedMessage", () => {
+    expect(E.isRight(EnrichedMessage.decode(aValidEnrichedMessage))).toBe(true)
+  })
+
+  it("should fail decoding an EnrichedMessage without organization fiscal code", () => {
+    expect(E.isLeft(EnrichedMessage.decode({ ...aValidEnrichedMessage, organization_fiscal_code: undefined }))).toBe(true)
+  })
+})
 
 describe("NewMessage definition", () => {
   it("should decode STANDARD NewMessage with content but without payment data", () => {

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -444,21 +444,10 @@ BaseEnrichedMessage:
     - service_name
     - organization_name
     - message_title
-
 EnrichedMessage:
   allOf:
     - $ref: "#/BaseEnrichedMessage"
     - $ref: "#/MessageStatusAttributes"
-
-EnrichedMessageWithOrganizationFiscalCode:
-  allOf:
-    - $ref: "#/EnrichedMessage"
-    - type: object
-      properties:
-        organization_fiscal_code:
-          $ref: "#/OrganizationFiscalCode"
-      required:
-        - organization_fiscal_code
 
 ExternalCreatedMessageWithoutContent:
   allOf:
@@ -526,9 +515,8 @@ ExternalMessageResponseWithContent:
 PublicMessage:
   x-one-of: true
   allOf:
-    - $ref: "#/EnrichedMessageWithOrganizationFiscalCode"
-    - $ref: "#/CreatedMessageWithoutContent"
-
+    - $ref: "#/EnrichedMessage"
+    - $ref: "#/CreatedMessageWithoutContent" 
 MessageResponseNotificationStatus:
   type: object
   properties:

--- a/openapi/definitions.yaml
+++ b/openapi/definitions.yaml
@@ -426,6 +426,8 @@ BaseEnrichedMessage:
       type: string
     organization_name:
       type: string
+    organization_fiscal_code:
+      $ref: "#/OrganizationFiscalCode"
     message_title:
       type: string
     category:
@@ -443,6 +445,7 @@ BaseEnrichedMessage:
     - sender_service_id
     - service_name
     - organization_name
+    - organization_fiscal_code
     - message_title
 EnrichedMessage:
   allOf:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

* Revert changes made in #379;
* Add organization fiscal code in `EnrichedMessage`;
* Add unit test for `EnrichedMessage` definition;

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Since io-app also need the organization fiscal code when calling GET `/messages/{id}` there is no need to add the definition `EnrichedMessageWithOrganizationFiscalCode` added in #379, we can simply add the `organization_fiscal_code` in the `EnrichedMessage` definition which is used to compose  `PaginatedPublicMessagesCollection` (the type of the response of GET `/messages/{fiscalCode}`) and `InternalMessageResponseWithContent` (the type of the response of GET `/messages/{id}`).

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Unit test.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
