### PR TITLE
[IOCOM-1504] Added new class method to get blob from most recent ContainerClient SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,12 @@
     "@types/winston": "^2.4.4",
     "auto-changelog": "^2.3.0",
     "eslint-plugin-prettier": "^3.4.0",
+    "fp-ts": "^2.16.5",
     "gulp": "^3.9.1",
     "gulp-prettier": "^3.0.0",
     "gulp-rename": "^2.0.0",
     "gulp-text-simple": "^0.5.5",
+    "io-ts": "^2.2.21",
     "jest": "^29.7.0",
     "json-set-map": "^1.1.2",
     "mjml": "^4.9.3",
@@ -51,13 +53,12 @@
     "prettier": "^1.14.3",
     "rimraf": "^2.7.1",
     "ts-jest": "^29.1.1",
-    "typescript": "^4.3.5",
-    "fp-ts": "^2.16.5",
-    "io-ts": "^2.2.21"
+    "typescript": "^4.3.5"
   },
   "dependencies": {
     "@azure/cosmos": "^4.0.0",
     "@azure/data-tables": "^13.2.2",
+    "@azure/storage-blob": "^12.23.0",
     "@pagopa/ts-commons": "^13.1.1",
     "applicationinsights": "^2.9.5",
     "azure-storage": "^2.10.5",

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-identical-functions */
 import { BlobService } from "azure-storage";
 import * as E from "fp-ts/lib/Either";
 import * as J from "fp-ts/Json";
@@ -15,6 +16,7 @@ import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
 import { flow, pipe } from "fp-ts/lib/function";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { ContainerClient } from "@azure/storage-blob";
 import {
   BaseModel,
   CosmosDecodingError,
@@ -41,7 +43,6 @@ import { NewMessageContent } from "../../generated/definitions/NewMessageContent
 import { FeatureLevelType } from "../../generated/definitions/FeatureLevelType";
 import { BlobNotFoundCode } from "../utils/azure_storage";
 import { CosmosdbModelTTL } from "../utils/cosmosdb_model_ttl";
-import { ContainerClient } from "@azure/storage-blob";
 
 export const MESSAGE_COLLECTION_NAME = "messages";
 export const MESSAGE_MODEL_PK_FIELD = "fiscalCode" as const;
@@ -392,6 +393,7 @@ export class MessageModel extends CosmosdbModelTTL<
   }
 
   /**
+   * @deprecated
    * Retrieve the message content from a blob
    *
    * @param blobService The azure.BlobService used to store the media

--- a/src/utils/azure_storage.ts
+++ b/src/utils/azure_storage.ts
@@ -234,7 +234,7 @@ export const getBlobFromContainerAsTextWithError = (
   pipe(
     TE.tryCatch(
       () => downloadBlobToString(containerClient, blobName),
-      _ => toStorageError("Blob storage: Internal error.")
+      _ => toStorageError("Blob storage: Internal error.", GenericCode)
     ),
     TE.chain(
       TE.fromPredicate(
@@ -245,13 +245,17 @@ export const getBlobFromContainerAsTextWithError = (
                 `Blob storage: Error code ${r.errorCode}.`,
                 r.errorCode
               )
-            : toStorageError("Blob storage: Empty response body.")
+            : toStorageError("Blob storage: Empty response body.", GenericCode)
       )
     ),
     TE.chain(res =>
       TE.tryCatch(
         () => streamToString(res.readableStreamBody!),
-        _ => toStorageError("Blob storage: Cannot parse stream to string.")
+        _ =>
+          toStorageError(
+            "Blob storage: Cannot parse stream to string.",
+            GenericCode
+          )
       )
     ),
     TE.map(fromNullable)
@@ -280,10 +284,11 @@ const streamToString = async (
   });
 };
 
-const toStorageError = (message: string, code?: string): StorageError => ({
-  ...new Error(message),
-  code
-});
+const toStorageError = (message: string, code: string): StorageError =>
+  ({
+    code,
+    message
+  } as StorageError);
 
 /**
  * Get a blob content as a typed (io-ts) object.

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,6 +86,38 @@
     "@azure/logger" "^1.0.0"
     tslib "^2.2.0"
 
+"@azure/core-client@^1.3.0", "@azure/core-client@^1.6.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@azure/core-client/-/core-client-1.9.2.tgz#6fc69cee2816883ab6c5cdd653ee4f2ff9774f74"
+  integrity sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==
+  dependencies:
+    "@azure/abort-controller" "^2.0.0"
+    "@azure/core-auth" "^1.4.0"
+    "@azure/core-rest-pipeline" "^1.9.1"
+    "@azure/core-tracing" "^1.0.0"
+    "@azure/core-util" "^1.6.1"
+    "@azure/logger" "^1.0.0"
+    tslib "^2.6.2"
+
+"@azure/core-http-compat@^2.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@azure/core-http-compat/-/core-http-compat-2.1.2.tgz#d1585ada24ba750dc161d816169b33b35f762f0d"
+  integrity sha512-5MnV1yqzZwgNLLjlizsU3QqOeQChkIXw781Fwh1xdAqJR5AA32IUaq6xv1BICJvfbHoa+JYcaij2HFkhLbNTJQ==
+  dependencies:
+    "@azure/abort-controller" "^2.0.0"
+    "@azure/core-client" "^1.3.0"
+    "@azure/core-rest-pipeline" "^1.3.0"
+
+"@azure/core-lro@^2.2.0":
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/@azure/core-lro/-/core-lro-2.7.2.tgz#787105027a20e45c77651a98b01a4d3b01b75a08"
+  integrity sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==
+  dependencies:
+    "@azure/abort-controller" "^2.0.0"
+    "@azure/core-util" "^1.2.0"
+    "@azure/logger" "^1.0.0"
+    tslib "^2.6.2"
+
 "@azure/core-paging@^1.1.1":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@azure/core-paging/-/core-paging-1.5.0.tgz#5a5b09353e636072e6a7fc38f7879e11d0afb15f"
@@ -123,6 +155,20 @@
     http-proxy-agent "^5.0.0"
     https-proxy-agent "^5.0.0"
     tslib "^2.2.0"
+
+"@azure/core-rest-pipeline@^1.10.1", "@azure/core-rest-pipeline@^1.3.0":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.0.tgz#631172e2fe0346cf4410d1c8e01ad98d849738e2"
+  integrity sha512-CeuTvsXxCUmEuxH5g/aceuSl6w2EugvNHKAtKKVdiX915EjJJxAwfzNNWZreNnbxHZ2fi0zaM6wwS23x2JVqSQ==
+  dependencies:
+    "@azure/abort-controller" "^2.0.0"
+    "@azure/core-auth" "^1.4.0"
+    "@azure/core-tracing" "^1.0.1"
+    "@azure/core-util" "^1.9.0"
+    "@azure/logger" "^1.0.0"
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.0"
+    tslib "^2.6.2"
 
 "@azure/core-rest-pipeline@^1.2.0":
   version "1.15.1"
@@ -169,6 +215,14 @@
     "@azure/abort-controller" "^2.0.0"
     tslib "^2.6.2"
 
+"@azure/core-util@^1.2.0", "@azure/core-util@^1.6.1", "@azure/core-util@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.9.0.tgz#469afd7e6452d5388b189f90d33f7756b0b210d1"
+  integrity sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==
+  dependencies:
+    "@azure/abort-controller" "^2.0.0"
+    tslib "^2.6.2"
+
 "@azure/core-util@^1.3.0":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.6.1.tgz#fea221c4fa43c26543bccf799beb30c1c7878f5a"
@@ -184,6 +238,14 @@
   dependencies:
     fast-xml-parser "^4.2.4"
     tslib "^2.2.0"
+
+"@azure/core-xml@^1.3.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@azure/core-xml/-/core-xml-1.4.2.tgz#9ce65e9520ebafc7b0c1f7115596282bfc7b32f3"
+  integrity sha512-CW3MZhApe/S4iikbYKE7s83fjDBPIr2kpidX+hlGRwh7N4o1nIpQ/PfJTeioqhfqdMvRtheEl+ft64fyTaLNaA==
+  dependencies:
+    fast-xml-parser "^4.3.2"
+    tslib "^2.6.2"
 
 "@azure/cosmos@^4.0.0":
   version "4.0.0"
@@ -245,6 +307,25 @@
     "@opentelemetry/api" "^1.4.1"
     "@opentelemetry/core" "^1.15.2"
     "@opentelemetry/instrumentation" "^0.41.2"
+    tslib "^2.2.0"
+
+"@azure/storage-blob@^12.23.0":
+  version "12.23.0"
+  resolved "https://registry.yarnpkg.com/@azure/storage-blob/-/storage-blob-12.23.0.tgz#36969427d1e4f961304278e980c50613f440b194"
+  integrity sha512-c1KJ5R5hqR/HtvmFtTn/Y1BNMq45NUBp0LZH7yF8WFMET+wmESgEr0FVTu/Z5NonmfUjbgJZG5Nh8xHc5RdWGQ==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-auth" "^1.4.0"
+    "@azure/core-client" "^1.6.2"
+    "@azure/core-http-compat" "^2.0.0"
+    "@azure/core-lro" "^2.2.0"
+    "@azure/core-paging" "^1.1.1"
+    "@azure/core-rest-pipeline" "^1.10.1"
+    "@azure/core-tracing" "^1.0.0"
+    "@azure/core-util" "^1.6.1"
+    "@azure/core-xml" "^1.3.2"
+    "@azure/logger" "^1.0.0"
+    events "^3.0.0"
     tslib "^2.2.0"
 
 "@babel/code-frame@7.12.11":
@@ -4025,6 +4106,11 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
+events@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -4165,6 +4251,13 @@ fast-xml-parser@^4.2.4:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz#761e641260706d6e13251c4ef8e3f5694d4b0d79"
   integrity sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==
+  dependencies:
+    strnum "^1.0.5"
+
+fast-xml-parser@^4.3.2:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz#341cc98de71e9ba9e651a67f41f1752d1441a501"
+  integrity sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
#### List of Changes
Added new class method to get blob from most recent ContainerClient SDK.
Added test.

#### Motivation and Context
We need to move to most recent SDK because `azure-storage` has been deprecated and will not support identity  based authentication.
The new `@azure/blob-storage` SDK contains the new `ContainerClient` that allows to use identity based connection.

#### How Has This Been Tested?
Unit Test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

